### PR TITLE
Enhance `useFetch` Hook with Default Parameters and Add Tests

### DIFF
--- a/src/__tests__/hooksTest/apiTest/useFetch.test.js
+++ b/src/__tests__/hooksTest/apiTest/useFetch.test.js
@@ -14,203 +14,239 @@ describe("useFetch Hook", () => {
     jest.restoreAllMocks();
   });
 
-  it("should handle GET request", async () => {
-    const mockResponse = { data: { id: 123 }, success: true };
-    axios.mockResolvedValueOnce({ data: mockResponse });
-
-    const onReceived = jest.fn();
-    const { result } = renderHook(() =>
-      useFetch("/test-route", "GET", null, {}, onReceived),
-    );
-
-    await act(async () => {
-      await result.current.performFetch();
+  // Tests for invalid configurations
+  describe("Invalid configurations", () => {
+    it("should throw error for missing or invalid initialRoute", () => {
+      expect(() => renderHook(() => useFetch())).toThrow(
+        "Invalid route provided. Routes cannot include 'api/' as part of the endpoint, to avoid conflicts and confusion in server routing.",
+      );
     });
 
-    expect(result.current.data).toEqual(mockResponse);
-    expect(onReceived).toHaveBeenCalledWith(mockResponse);
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.error).toBeNull();
-  });
-
-  it("should handle POST request", async () => {
-    const mockResponse = { data: { id: 123 }, success: true };
-    axios.mockResolvedValueOnce({ data: mockResponse });
-
-    const onReceived = jest.fn();
-    const { result } = renderHook(() =>
-      useFetch("/test-route", "POST", { id: 123 }, {}, onReceived),
-    );
-
-    await act(async () => {
-      await result.current.performFetch();
+    it("should handle null request parameters", () => {
+      expect(() =>
+        renderHook(() => useFetch(null, "GET", null, {}, jest.fn())),
+      ).toThrow("Invalid route provided");
     });
-
-    expect(result.current.data).toEqual(mockResponse);
-    expect(onReceived).toHaveBeenCalledWith(mockResponse);
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.error).toBeNull();
   });
 
-  it("should handle PUT request", async () => {
-    const mockResponse = { data: { id: 123, updated: true }, success: true };
-    axios.mockResolvedValueOnce({ data: mockResponse });
+  // Tests for HTTP methods
+  describe("HTTP methods", () => {
+    it("should handle GET request", async () => {
+      const mockResponse = { data: { id: 123 }, success: true };
+      axios.mockResolvedValueOnce({ data: mockResponse });
 
-    const onReceived = jest.fn();
-    const { result } = renderHook(() =>
-      useFetch("/test-route", "PUT", { id: 123 }, {}, onReceived),
-    );
+      const { result } = renderHook(() => useFetch("/test-route", "GET"));
 
-    await act(async () => {
-      await result.current.performFetch();
-    });
+      await act(async () => {
+        await result.current.performFetch();
+      });
 
-    expect(result.current.data).toEqual(mockResponse);
-    expect(onReceived).toHaveBeenCalledWith(mockResponse);
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.error).toBeNull();
-  });
-
-  it("should handle null request parameters", () => {
-    // The renderHook itself will trigger the hook and we need to catch the error.
-    expect(() =>
-      renderHook(() => useFetch(null, "GET", null, {}, jest.fn())),
-    ).toThrow("Invalid route provided");
-  });
-
-  it("should handle DELETE request", async () => {
-    const mockResponse = { data: { id: 123, deleted: true }, success: true };
-    axios.mockResolvedValueOnce({ data: mockResponse });
-
-    const onReceived = jest.fn();
-    const { result } = renderHook(() =>
-      useFetch("/test-route", "DELETE", null, {}, onReceived),
-    );
-
-    await act(async () => {
-      await result.current.performFetch();
-    });
-
-    expect(result.current.data).toEqual(mockResponse);
-    expect(onReceived).toHaveBeenCalledWith(mockResponse);
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.error).toBeNull();
-  });
-
-  it("should handle failed GET request", async () => {
-    axios.mockRejectedValueOnce(new Error("Network Error"));
-
-    const onReceived = jest.fn();
-    const { result } = renderHook(() =>
-      useFetch("/test-route", "GET", null, {}, onReceived),
-    );
-
-    await act(async () => {
-      await result.current.performFetch();
-    });
-
-    await waitFor(() => {
+      expect(result.current.data).toEqual(mockResponse);
       expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+
+    it("should handle POST request", async () => {
+      const mockResponse = { data: { id: 123 }, success: true };
+      axios.mockResolvedValueOnce({ data: mockResponse });
+
+      const onReceived = jest.fn();
+      const { result } = renderHook(() =>
+        useFetch("/test-route", "POST", { id: 123 }, {}, onReceived),
+      );
+
+      await act(async () => {
+        await result.current.performFetch();
+      });
+
+      expect(result.current.data).toEqual(mockResponse);
+      expect(onReceived).toHaveBeenCalledWith(mockResponse);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+
+    it("should handle PUT request", async () => {
+      const mockResponse = { data: { id: 123, updated: true }, success: true };
+      axios.mockResolvedValueOnce({ data: mockResponse });
+
+      const onReceived = jest.fn();
+      const { result } = renderHook(() =>
+        useFetch("/test-route", "PUT", { id: 123 }, {}, onReceived),
+      );
+
+      await act(async () => {
+        await result.current.performFetch();
+      });
+
+      expect(result.current.data).toEqual(mockResponse);
+      expect(onReceived).toHaveBeenCalledWith(mockResponse);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+
+    it("should handle DELETE request", async () => {
+      const mockResponse = { data: { id: 123, deleted: true }, success: true };
+      axios.mockResolvedValueOnce({ data: mockResponse });
+
+      const onReceived = jest.fn();
+      const { result } = renderHook(() =>
+        useFetch("/test-route", "DELETE", null, {}, onReceived),
+      );
+
+      await act(async () => {
+        await result.current.performFetch();
+      });
+
+      expect(result.current.data).toEqual(mockResponse);
+      expect(onReceived).toHaveBeenCalledWith(mockResponse);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+
+    it("should handle null body gracefully", async () => {
+      const mockResponse = { data: { id: 123 }, success: true };
+      axios.mockResolvedValueOnce({ data: mockResponse });
+
+      const { result } = renderHook(() => useFetch("/test-route", "POST"));
+
+      await act(async () => {
+        await result.current.performFetch();
+      });
+
+      expect(result.current.data).toEqual(mockResponse);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  // Tests for errors and edge cases
+  describe("Error handling", () => {
+    it("should handle failed GET request", async () => {
+      axios.mockRejectedValueOnce(new Error("Network Error"));
+
+      const { result } = renderHook(() => useFetch("/test-route", "GET"));
+
+      await act(async () => {
+        await result.current.performFetch();
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.error).toBeInstanceOf(Error);
+        expect(result.current.error.message).toBe("Network Error");
+      });
+    });
+
+    it("should handle invalid URL", async () => {
+      const { result } = renderHook(() => useFetch("invalid-url", "GET"));
+
+      await act(async () => {
+        await result.current.performFetch();
+      });
+
       expect(result.current.error).toBeInstanceOf(Error);
-      expect(result.current.error.message).toBe("Network Error");
+      expect(result.current.error.message).toBe("Invalid URL");
+    });
+
+    it("should handle empty response", async () => {
+      axios.mockResolvedValueOnce({ data: {} });
+
+      const { result } = renderHook(() => useFetch("/test-route", "GET"));
+
+      await act(async () => {
+        await result.current.performFetch();
+      });
+
+      expect(result.current.error).toBeInstanceOf(Error);
+      expect(result.current.error.message).toBe("Empty response from server");
+    });
+
+    it("should handle generic server error", async () => {
+      const mockErrorResponse = {
+        response: { data: { msg: "Internal server error." } },
+      };
+      axios.mockRejectedValueOnce(mockErrorResponse);
+
+      const { result } = renderHook(() => useFetch("/test-route", "GET"));
+
+      await act(async () => {
+        await result.current.performFetch();
+      });
+
+      expect(result.current.error).toBeInstanceOf(Error);
+      expect(result.current.error.message).toBe("Internal server error.");
     });
   });
 
-  it("should handle invalid URL", async () => {
-    const onReceived = jest.fn();
-    const { result } = renderHook(() =>
-      useFetch("invalid-url", "GET", null, {}, onReceived),
-    );
+  // Tests for configuration defaults
+  describe("Configuration and defaults", () => {
+    it("should use default headers when customHeaders is not provided", async () => {
+      const mockResponse = { data: { id: 123 }, success: true };
+      axios.mockResolvedValueOnce({ data: mockResponse });
 
-    await act(async () => {
-      await result.current.performFetch();
+      const { result } = renderHook(() => useFetch("/test-route", "GET"));
+
+      await act(async () => {
+        await result.current.performFetch();
+      });
+
+      expect(axios).toHaveBeenCalledWith(expect.any(String), {
+        method: "GET",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+        }),
+        withCredentials: true,
+        cancelToken: expect.any(Object),
+      });
     });
 
-    expect(result.current.error).toBeInstanceOf(Error);
-    expect(result.current.error.message).toBe("Invalid URL");
+    it("should not fail if onReceived is not provided", async () => {
+      const mockResponse = { data: { id: 123 }, success: true };
+      axios.mockResolvedValueOnce({ data: mockResponse });
+
+      const { result } = renderHook(() => useFetch("/test-route", "GET"));
+
+      await act(async () => {
+        await result.current.performFetch();
+      });
+
+      expect(result.current.data).toEqual(mockResponse);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
   });
 
-  it("should call cancelFetch", () => {
-    const onReceived = jest.fn();
-    const { result } = renderHook(() =>
-      useFetch("/test-route", "GET", null, {}, onReceived),
-    );
-    const spyCancelFetch = jest.spyOn(result.current, "cancelFetch");
+  // Tests for lifecycle methods
+  describe("Lifecycle methods", () => {
+    it("should call cancelFetch", () => {
+      const { result } = renderHook(() => useFetch("/test-route", "GET"));
+      const spyCancelFetch = jest.spyOn(result.current, "cancelFetch");
 
-    act(() => {
-      result.current.cancelFetch();
+      act(() => {
+        result.current.cancelFetch();
+      });
+
+      expect(spyCancelFetch).toHaveBeenCalled();
+
+      spyCancelFetch.mockRestore();
     });
 
-    expect(spyCancelFetch).toHaveBeenCalled();
+    it("should return cancelFetch function", () => {
+      const { result } = renderHook(() => useFetch("/test-route", "GET"));
 
-    spyCancelFetch.mockRestore();
-  });
-
-  it("should return cancelFetch function", () => {
-    const onReceived = jest.fn();
-    const { result } = renderHook(() =>
-      useFetch("/test-route", "GET", null, {}, onReceived),
-    );
-
-    expect(typeof result.current.cancelFetch).toBe("function");
-  });
-
-  it("should handle empty response", async () => {
-    // Mocking an API response that is an empty object
-    axios.mockResolvedValueOnce({ data: {} });
-
-    const onReceived = jest.fn();
-    const { result } = renderHook(() =>
-      useFetch("/test-route", "GET", null, {}, onReceived),
-    );
-
-    await act(async () => {
-      await result.current.performFetch();
+      expect(typeof result.current.cancelFetch).toBe("function");
     });
 
-    expect(result.current.error).toBeInstanceOf(Error);
-    expect(result.current.error.message).toBe("Empty response from server");
-  });
+    it("should set isLoading to true while fetching", async () => {
+      const { result } = renderHook(() => useFetch("/test-route", "GET"));
 
-  it("should handle generic server error", async () => {
-    const mockErrorResponse = {
-      response: {
-        data: {
-          msg: "Internal server error.",
-        },
-      },
-    };
+      expect(result.current.isLoading).toBe(false);
 
-    axios.mockRejectedValueOnce(mockErrorResponse);
+      await act(async () => {
+        await result.current.performFetch();
+      });
 
-    const onReceived = jest.fn();
-    const { result } = renderHook(() =>
-      useFetch("/test-route", "GET", null, {}, onReceived),
-    );
-
-    await act(async () => {
-      await result.current.performFetch();
+      expect(result.current.isLoading).toBe(false);
     });
-
-    expect(result.current.error).toBeInstanceOf(Error);
-    expect(result.current.error.message).toBe("Internal server error.");
-  });
-
-  it("should set isLoading to true while fetching", async () => {
-    const onReceived = jest.fn();
-    const { result } = renderHook(() =>
-      useFetch("/test-route", "GET", null, {}, onReceived),
-    );
-
-    // Initially, isLoading should be false
-    expect(result.current.isLoading).toBe(false);
-
-    // Start the fetch request
-    await act(async () => {
-      await result.current.performFetch();
-    });
-
-    // After the fetch request is performed, isLoading should be false
-    expect(result.current.isLoading).toBe(false);
   });
 });

--- a/src/hooks/api/useFetch.js
+++ b/src/hooks/api/useFetch.js
@@ -8,7 +8,7 @@ const useFetch = (
   method = "GET",
   body = null,
   customHeaders = {},
-  onReceived,
+  onReceived = () => {},
 ) => {
   // Validate initial inputs to avoid confusion with server routing
   if (!initialRoute || initialRoute.includes("api/")) {


### PR DESCRIPTION
### Pull Request Description:

This pull request:  the `onReceived` callback is now optional and defaults to an empty function (`() => {}`). 

### Changes:

- **Optional `onReceived` parameter**: The `onReceived` callback is now optional and defaults to `() => {}` if not provided.

### Added Tests:

We have added multiple tests to ensure that the hook behaves correctly with missing or default parameters:

1. **Test for missing `onReceived` callback**: Verifies that the hook works without the `onReceived` callback, which is now optional.

2. **Test for missing optional parameters**: Ensures that the hook behaves as expected when optional parameters like `body` or `customHeaders` are not provided.

### Test Snippet:

```javascript
it("should not fail if onReceived is not provided", async () => {
  const mockResponse = { data: { id: 123 }, success: true };
  axios.mockResolvedValueOnce({ data: mockResponse });

  const { result } = renderHook(() => useFetch("/test-route", "GET")); // Without `onReceived`

  await act(async () => {
    await result.current.performFetch();
  });

  expect(result.current.data).toEqual(mockResponse); // Does not fail even if onReceived is not passed
  expect(result.current.isLoading).toBe(false);
  expect(result.current.error).toBeNull();
});
```

### Summary:
- This PR improves the flexibility of the `useFetch` hook by allowing optional parameters and default values.
- It ensures that no errors are thrown when parameters are missing and that the hook works seamlessly with different configurations.

Please review the changes and let me know if you have any feedback.

---
