### PR TITLE
Enhance PhotoCard Components for Mobile and Small Screens

### DIFF
--- a/src/__tests__/componentsTest/PhotoCard.test.js
+++ b/src/__tests__/componentsTest/PhotoCard.test.js
@@ -12,24 +12,24 @@ describe("PhotoCard Component", () => {
     buttonLabel: "Test Button",
     buttonVariant: "secondary-darker",
     buttonTestId: "test-button",
-    cardVariant: "variant1", // Cambiar la variante si es necesario
+    cardVariant: "variant1",
   };
 
   it("renders without crashing", () => {
     render(<PhotoCard {...defaultProps} />);
-    // Verificamos que el contenedor de la tarjeta se haya renderizado
+
     expect(screen.getByTestId("photoDiv")).toBeInTheDocument();
   });
 
   it("displays the correct title", () => {
     render(<PhotoCard {...defaultProps} />);
-    // Verificamos que el título esté presente
+
     expect(screen.getByText(defaultProps.title)).toBeInTheDocument();
   });
 
   it("displays the correct description", () => {
     render(<PhotoCard {...defaultProps} />);
-    // Verificamos que la descripción esté presente
+
     expect(screen.getByText(defaultProps.description)).toBeInTheDocument();
   });
 

--- a/src/__tests__/componentsTest/PhotoCard.test.js
+++ b/src/__tests__/componentsTest/PhotoCard.test.js
@@ -18,24 +18,29 @@ describe("PhotoCard Component", () => {
   it("renders without crashing", () => {
     render(<PhotoCard {...defaultProps} />);
 
-    expect(screen.getByTestId("photoDiv")).toBeInTheDocument();
+    expect(screen.getByTestId("photo-card")).toBeInTheDocument();
   });
 
   it("displays the correct title", () => {
     render(<PhotoCard {...defaultProps} />);
 
-    expect(screen.getByText(defaultProps.title)).toBeInTheDocument();
+    expect(screen.getByTestId("photo-card-title")).toHaveTextContent(
+      defaultProps.title,
+    );
   });
 
   it("displays the correct description", () => {
     render(<PhotoCard {...defaultProps} />);
 
-    expect(screen.getByText(defaultProps.description)).toBeInTheDocument();
+    expect(screen.getByTestId("photo-card-description")).toHaveTextContent(
+      defaultProps.description,
+    );
   });
 
   it("displays the image with the correct src and alt attributes", () => {
     render(<PhotoCard {...defaultProps} />);
-    const img = screen.getByAltText(defaultProps.title);
+
+    const img = screen.getByTestId("card-image");
     expect(img).toHaveAttribute("src", defaultProps.imageUrl);
     expect(img).toHaveAttribute("alt", defaultProps.title);
   });
@@ -43,12 +48,15 @@ describe("PhotoCard Component", () => {
   it("displays the button with the correct label", () => {
     render(<PhotoCard {...defaultProps} />);
 
-    expect(screen.getByText(defaultProps.buttonLabel)).toBeInTheDocument();
+    expect(screen.getByTestId("test-button")).toHaveTextContent(
+      defaultProps.buttonLabel,
+    );
   });
 
   it("applies correct styles based on the cardVariant", () => {
     render(<PhotoCard {...defaultProps} />);
-    const photoCard = screen.getByTestId("photoDiv");
+
+    const photoCard = screen.getByTestId("photo-card");
 
     if (defaultProps.cardVariant === "variant1") {
       expect(photoCard).toHaveClass(

--- a/src/__tests__/componentsTest/PhotoCard.test.js
+++ b/src/__tests__/componentsTest/PhotoCard.test.js
@@ -7,46 +7,59 @@ describe("PhotoCard Component", () => {
   const defaultProps = {
     imageUrl: "/test-image.jpg",
     title: "Test Title",
-    smallScreenTitle: "Small Screen Title",
     description: "Test description for PhotoCard.",
     buttonIcon: "/test-icon.svg",
     buttonLabel: "Test Button",
-    backgroundColor: "#ffffff",
-    fontColor: "#000000",
-    buttonBgColor: "#123456",
-    buttonFontColor: "#abcdef",
+    buttonVariant: "secondary-darker",
+    buttonTestId: "test-button",
+    cardVariant: "variant1", // Cambiar la variante si es necesario
   };
 
   it("renders without crashing", () => {
     render(<PhotoCard {...defaultProps} />);
+    // Verificamos que el contenedor de la tarjeta se haya renderizado
+    expect(screen.getByTestId("photoDiv")).toBeInTheDocument();
   });
 
-  it("displays the correct title for large screens", () => {
-    global.innerWidth = 1320;
-    global.dispatchEvent(new Event("resize"));
+  it("displays the correct title", () => {
     render(<PhotoCard {...defaultProps} />);
+    // Verificamos que el título esté presente
     expect(screen.getByText(defaultProps.title)).toBeInTheDocument();
   });
 
-  it("displays the small screen title when the screen width is small", () => {
-    global.innerWidth = 600; // Simulate a small screen
-    global.dispatchEvent(new Event("resize")); // Trigger resize event
+  it("displays the correct description", () => {
     render(<PhotoCard {...defaultProps} />);
-    expect(screen.getByText(defaultProps.smallScreenTitle)).toBeInTheDocument();
+    // Verificamos que la descripción esté presente
+    expect(screen.getByText(defaultProps.description)).toBeInTheDocument();
   });
 
   it("displays the image with the correct src and alt attributes", () => {
     render(<PhotoCard {...defaultProps} />);
     const img = screen.getByAltText(defaultProps.title);
     expect(img).toHaveAttribute("src", defaultProps.imageUrl);
+    expect(img).toHaveAttribute("alt", defaultProps.title);
   });
 
-  it("displays the button with the correct label and styles", () => {
+  it("displays the button with the correct label", () => {
     render(<PhotoCard {...defaultProps} />);
-    const button = screen.getByText(defaultProps.buttonLabel);
-    expect(button).toBeInTheDocument();
-    expect(button.closest("button")).toHaveStyle(
-      `background-color: ${defaultProps.buttonBgColor}`,
-    );
+
+    expect(screen.getByText(defaultProps.buttonLabel)).toBeInTheDocument();
+  });
+
+  it("applies correct styles based on the cardVariant", () => {
+    render(<PhotoCard {...defaultProps} />);
+    const photoCard = screen.getByTestId("photoDiv");
+
+    if (defaultProps.cardVariant === "variant1") {
+      expect(photoCard).toHaveClass(
+        "bg-tertiary1-hover",
+        "text-tertiary1-darker",
+      );
+    } else if (defaultProps.cardVariant === "variant2") {
+      expect(photoCard).toHaveClass(
+        "bg-secondary-normal",
+        "text-secondary-light",
+      );
+    }
   });
 });

--- a/src/__tests__/componentsTest/PhotoCardsWineTasting.test.js
+++ b/src/__tests__/componentsTest/PhotoCardsWineTasting.test.js
@@ -28,4 +28,18 @@ describe("PhotoCardsWineTasting Component", () => {
     const grid = screen.getByTestId("photo-cards-wine-tasting");
     expect(grid).toHaveClass("sm:grid-cols-2");
   });
+
+  it("checks if the background and text color classes are correct in variant 1", () => {
+    render(<PhotoCardsWineTasting />);
+    const photoCard = screen.getAllByTestId("photoDiv")[0];
+
+    expect(photoCard).toHaveClass("bg-tertiary1-hover text-tertiary1-darker");
+  });
+
+  it("checks if the background and text color classes are correct in variant 2", () => {
+    render(<PhotoCardsWineTasting />);
+    const photoCard = screen.getAllByTestId("photoDiv")[1];
+
+    expect(photoCard).toHaveClass("bg-secondary-normal text-secondary-light");
+  });
 });

--- a/src/__tests__/componentsTest/PhotoCardsWineTasting.test.js
+++ b/src/__tests__/componentsTest/PhotoCardsWineTasting.test.js
@@ -1,27 +1,31 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import PhotoCardsWineTasting from "@/components/ContentGrid/PhotoCardsWineTasting";
 
 describe("PhotoCardsWineTasting Component", () => {
   it("renders without crashing", () => {
     render(<PhotoCardsWineTasting />);
+    expect(screen.getByTestId("photo-cards-wine-tasting")).toBeInTheDocument();
   });
 
   it("renders the correct number of PhotoCard components", () => {
     render(<PhotoCardsWineTasting />);
     const photoCards = screen.getAllByTestId("photoDiv");
-    expect(photoCards).toHaveLength(2);
+    expect(photoCards.length).toBe(2);
   });
 
-  it("renders the grid layout correctly for screen-sizes BELOW md", async () => {
-    Object.defineProperty(window, "innerWidth", { value: 600 });
-    global.dispatchEvent(new Event("resize"));
+  it("renders the grid layout correctly for screen-sizes BELOW sm", () => {
+    window.innerWidth = 400;
     render(<PhotoCardsWineTasting />);
-    const grid = await screen.getByTestId("testGrid");
-    await waitFor(() => {
-      expect(grid).toBeInTheDocument();
-      expect(grid).toHaveClass("grid-cols-1");
-    });
+    const grid = screen.getByTestId("photo-cards-wine-tasting");
+    expect(grid).toHaveClass("grid-col-1");
+  });
+
+  it("renders the grid layout correctly for screen-sizes ABOVE sm", () => {
+    window.innerWidth = 640;
+    render(<PhotoCardsWineTasting />);
+    const grid = screen.getByTestId("photo-cards-wine-tasting");
+    expect(grid).toHaveClass("sm:grid-cols-2");
   });
 });

--- a/src/__tests__/componentsTest/PhotoCardsWineTasting.test.js
+++ b/src/__tests__/componentsTest/PhotoCardsWineTasting.test.js
@@ -11,7 +11,7 @@ describe("PhotoCardsWineTasting Component", () => {
 
   it("renders the correct number of PhotoCard components", () => {
     render(<PhotoCardsWineTasting />);
-    const photoCards = screen.getAllByTestId("photoDiv");
+    const photoCards = screen.getAllByTestId("photo-card");
     expect(photoCards.length).toBe(2);
   });
 
@@ -31,14 +31,14 @@ describe("PhotoCardsWineTasting Component", () => {
 
   it("checks if the background and text color classes are correct in variant 1", () => {
     render(<PhotoCardsWineTasting />);
-    const photoCard = screen.getAllByTestId("photoDiv")[0];
+    const photoCard = screen.getAllByTestId("photo-card")[0];
 
     expect(photoCard).toHaveClass("bg-tertiary1-hover text-tertiary1-darker");
   });
 
   it("checks if the background and text color classes are correct in variant 2", () => {
     render(<PhotoCardsWineTasting />);
-    const photoCard = screen.getAllByTestId("photoDiv")[1];
+    const photoCard = screen.getAllByTestId("photo-card")[1];
 
     expect(photoCard).toHaveClass("bg-secondary-normal text-secondary-light");
   });

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -9,7 +9,7 @@ import PhotoCardsTeamValues from "@/components/ContentGrid/PhotoCardsTeamValues"
 export default function Home() {
   return (
     <div className="flex w-[100%]" data-testid="home-container">
-      <main data-testid="main-heading">
+      <main className="flex flex-col gap-4" data-testid="main-heading">
         <HeroSection />
         <PhotoCardsWineTasting />
         <Subscribe />

--- a/src/components/Card/PhotoCard.js
+++ b/src/components/Card/PhotoCard.js
@@ -23,30 +23,39 @@ const PhotoCard = ({
 
   return (
     <div
-      className={`photoDiv relative flex flex-col rounded-3xl overflow-hidden w-[21.5rem] h-[37.5rem] xl:flex-row xl:w-[35.2rem] xl:h-[26.8rem] 2xl:w-[39.6rem] 2xl:h-[30.15rem] 3xl:w-[44rem] 3xl:h-[33.5rem] ${variantClass}`}
+      className={`relative flex flex-col rounded-3xl overflow-hidden w-[21.5rem] h-[37.5rem] xl:flex-row xl:w-[35.2rem] xl:h-[26.8rem] 2xl:w-[39.6rem] 2xl:h-[30.15rem] 3xl:w-[44rem] 3xl:h-[33.5rem] ${variantClass}`}
       data-testid="photoDiv"
       aria-label={`Photo card with title: ${title}`}
     >
       <img
         src={imageUrl}
         alt={title}
-        className="cardImg object-cover h-[12.375rem] w-[21.5rem] xl:h-full xl:w-[20.6rem] 2xl:w-[23.175rem] 3xl:w-[25.75rem]"
+        className="object-cover h-[12.375rem] w-[21.5rem] xl:h-full xl:w-[20.6rem] 2xl:w-[23.175rem] 3xl:w-[25.75rem]"
+        data-testid="card-image"
         aria-label={`Image representing ${title}`}
       />
-      <div className="flex flex-col justify-center p-6">
+      <div
+        className="flex flex-col justify-center p-6"
+        data-testid="card-content"
+      >
         <h3
-          className="cardHeading relative text-headlineLarge xl:text-displaySmall 3xl:text-displayMedium font-barlow font-medium mb-7 mt-1 xl:mb-3 xl:mt-1 xl:mb-5 2xl:mb-6 xl:bottom-2 2xl:bottom-1 3xl:mb-7"
+          className="relative text-headlineLarge xl:text-displaySmall 3xl:text-displayMedium font-barlow font-medium mb-7 mt-1 xl:mb-3 xl:mt-1 xl:mb-5 2xl:mb-6 xl:bottom-2 2xl:bottom-1 3xl:mb-7"
+          data-testid="card-title"
           aria-label={`Card title: ${title}`}
         >
           {title}
         </h3>
         <p
-          className="cardDescription relative font-barlow text-bodyLarge xl:text-bodyMedium 2xl:text-bodyLarge font-regular mb-8 rounded xl:bottom-2 2xl:bottom-2 3xl:bottom-3"
+          className="relative font-barlow text-bodyLarge xl:text-bodyMedium 2xl:text-bodyLarge font-regular mb-8 rounded xl:bottom-2 2xl:bottom-2 3xl:bottom-3"
+          data-testid="card-description"
           aria-label={`Card description: ${description}`}
         >
           {description}
         </p>
-        <div className="absolute bottom-10 left-1/2 transform -translate-x-1/2 flex justify-center items-center mt-2 xl:mt-0 xl:bottom-7 xl:left-auto xl:translate-x-0 xl:justify-start xl:ml-1 2xl:bottom-8 3xl:bottom-8">
+        <div
+          className="absolute bottom-10 left-1/2 transform -translate-x-1/2 flex justify-center items-center mt-2 xl:mt-0 xl:bottom-7 xl:left-auto xl:translate-x-0 xl:justify-start xl:ml-1 2xl:bottom-8 3xl:bottom-8"
+          data-testid="card-button-container"
+        >
           <Button
             text={buttonLabel}
             icon={buttonIcon}

--- a/src/components/Card/PhotoCard.js
+++ b/src/components/Card/PhotoCard.js
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
+import Button from "../Button/Button";
 
 const PhotoCard = ({
   imageUrl,
@@ -12,8 +13,8 @@ const PhotoCard = ({
   buttonLabel,
   backgroundColor,
   fontColor,
-  buttonBgColor,
-  buttonFontColor,
+  buttonVariant,
+  buttonTestId,
 }) => {
   const [isSmallScreen, setIsSmallScreen] = useState(false);
 
@@ -29,7 +30,7 @@ const PhotoCard = ({
 
   return (
     <div
-      className="photoDiv relative flex flex-col rounded-3xl overflow-hidden w-[21.5rem] h-[37.5rem] xl:flex-row xl:flex-row xl:w-[35.2rem] xl:h-[26.8rem] 2xl:w-[39.6rem] 2xl:h-[30.15rem] 3xl:w-[44rem] 3xl:h-[33.5rem]"
+      className="photoDiv relative flex flex-col rounded-3xl overflow-hidden w-[21.5rem] h-[37.5rem] xl:flex-row xl:w-[35.2rem] xl:h-[26.8rem] 2xl:w-[39.6rem] 2xl:h-[30.15rem] 3xl:w-[44rem] 3xl:h-[33.5rem]"
       data-testid="photoDiv"
       style={{
         backgroundColor: backgroundColor,
@@ -58,43 +59,34 @@ const PhotoCard = ({
           {description}
         </p>
         <div className="absolute bottom-10 left-1/2 transform -translate-x-1/2 flex justify-center items-center mt-2 xl:mt-0 xl:bottom-7 xl:left-auto xl:translate-x-0 xl:justify-start xl:ml-1 2xl:bottom-8 3xl:bottom-8">
-          <button
-            className="flex items-center justify-center w-[12.125rem] h-[2.8rem] xl:w-[10.9125rem] xl:h-[2.5rem] 2xl:w-[10.9125rem] 2xl:h-[2.7rem] 3xl:w-[12.125rem] 3xl:h-[3rem] gap-2 px-4 py-2 rounded"
-            style={{
-              backgroundColor: buttonBgColor,
-            }}
-            aria-label={`Click to ${buttonLabel}`}
-          >
-            <img src={buttonIcon} alt={`${buttonLabel} icon`}></img>
-            <span
-              className="font-medium text-labelLarge xl:text-labelMedium 3xl:text-labelLarge"
-              style={{ color: buttonFontColor }}
-            >
-              {buttonLabel}
-            </span>
-          </button>
+          <Button
+            text={buttonLabel}
+            icon={buttonIcon}
+            variant={buttonVariant}
+            testId={buttonTestId}
+            ariaLabel={buttonLabel}
+          />
         </div>
       </div>
     </div>
   );
 };
 
-// Prop validation
 PhotoCard.propTypes = {
-  imageUrl: PropTypes.string.isRequired, // Image URL must be a string and is required
-  title: PropTypes.string.isRequired, // Title must be a string and is required
-  smallScreenTitle: PropTypes.string, // Title must be a string and is required
-  description: PropTypes.string.isRequired, // Description must be a string and is required
-  buttonIcon: PropTypes.string, // Icon URL should be a string (optional)
-  buttonLabel: PropTypes.string.isRequired, // Button label must be a string and is required
-  backgroundColor: PropTypes.string.isRequired, // Background color must be a string and is required
-  fontColor: PropTypes.string.isRequired, // Font color must be a string and is required
-  buttonBgColor: PropTypes.string.isRequired, // Button background color must be a string and is required
-  buttonFontColor: PropTypes.string.isRequired, // Button font color must be a string and is required
+  imageUrl: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  smallScreenTitle: PropTypes.string,
+  description: PropTypes.string.isRequired,
+  buttonIcon: PropTypes.string,
+  buttonLabel: PropTypes.string.isRequired,
+  backgroundColor: PropTypes.string.isRequired,
+  fontColor: PropTypes.string.isRequired,
+  buttonVariant: PropTypes.string.isRequired,
+  buttonTestId: PropTypes.string.isRequired,
 };
 
 PhotoCard.defaultProps = {
-  buttonIcon: null, // Default value for the optional buttonIcon
+  buttonIcon: null,
 };
 
 export default PhotoCard;

--- a/src/components/Card/PhotoCard.js
+++ b/src/components/Card/PhotoCard.js
@@ -1,13 +1,12 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import Button from "../Button/Button";
 
 const PhotoCard = ({
   imageUrl,
   title,
-  smallScreenTitle,
   description,
   buttonIcon,
   buttonLabel,
@@ -16,18 +15,6 @@ const PhotoCard = ({
   buttonVariant,
   buttonTestId,
 }) => {
-  const [isSmallScreen, setIsSmallScreen] = useState(false);
-
-  useEffect(() => {
-    const handleResize = () => {
-      setIsSmallScreen(window.innerWidth < 1280);
-    };
-
-    handleResize();
-    window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
-  }, []);
-
   return (
     <div
       className="photoDiv relative flex flex-col rounded-3xl overflow-hidden w-[21.5rem] h-[37.5rem] xl:flex-row xl:w-[35.2rem] xl:h-[26.8rem] 2xl:w-[39.6rem] 2xl:h-[30.15rem] 3xl:w-[44rem] 3xl:h-[33.5rem]"

--- a/src/components/Card/PhotoCard.js
+++ b/src/components/Card/PhotoCard.js
@@ -23,13 +23,13 @@ const PhotoCard = ({
 
   return (
     <article
-      className={`relative flex flex-col rounded-[2rem] w-full h-auto sm:h-[33.5rem] sm:flex-row ${variantClass}`}
+      className={`relative flex flex-col rounded-[2rem] w-full h-[37.5rem] sm:h-[33.5rem] sm:flex-row gap-8 items-center ${variantClass}`}
       data-testid="photo-card"
       aria-labelledby="photo-card-title"
       aria-describedby="photo-card-description"
     >
       <figure
-        className={`overflow-hidden rounded-tl-[2rem] rounded-tr-[2rem] sm:rounded-tr-none sm:rounded-tl-[2rem] sm:rounded-bl-[2rem] w-full h-auto sm:h-[33.5rem] sm:flex-row ${variantClass}`}
+        className={`overflow-hidden rounded-tl-[2rem] rounded-tr-[2rem] sm:rounded-tr-none sm:rounded-tl-[2rem] sm:rounded-bl-[2rem] ${variantClass}`}
         data-testid="photo-card-image"
         aria-labelledby="photo-card-title"
       >
@@ -43,11 +43,11 @@ const PhotoCard = ({
       </figure>
 
       <div
-        className="flex flex-col justify-center gap-8 sm:p-6 sm:py-8 sm:w-[18.25rem]"
+        className="flex flex-col w-[18.5rem] sm:w-[18.25] gap-8 sm:p-6 sm:py-8 "
         data-testid="photo-card-content"
       >
         <h3
-          className="text-displaySmall font-barlow font-medium justify-center"
+          className="text-displaySmall font-barlow font-medium "
           id="photo-card-title"
           data-testid="photo-card-title"
           aria-label={`Card title: ${title}`}

--- a/src/components/Card/PhotoCard.js
+++ b/src/components/Card/PhotoCard.js
@@ -4,24 +4,27 @@ import React from "react";
 import PropTypes from "prop-types";
 import Button from "../Button/Button";
 
+const VARIANT_CLASSES = {
+  variant1: "bg-tertiary1-hover text-tertiary1-darker",
+  variant2: "bg-secondary-normal text-secondary-light",
+};
+
 const PhotoCard = ({
   imageUrl,
   title,
   description,
   buttonIcon,
   buttonLabel,
-  backgroundColor,
-  fontColor,
   buttonVariant,
   buttonTestId,
+  cardVariant,
 }) => {
+  const variantClass = VARIANT_CLASSES[cardVariant] || VARIANT_CLASSES.variant1; // Default to variant1
+
   return (
     <div
-      className="photoDiv relative flex flex-col rounded-3xl overflow-hidden w-[21.5rem] h-[37.5rem] xl:flex-row xl:w-[35.2rem] xl:h-[26.8rem] 2xl:w-[39.6rem] 2xl:h-[30.15rem] 3xl:w-[44rem] 3xl:h-[33.5rem]"
+      className={`photoDiv relative flex flex-col rounded-3xl overflow-hidden w-[21.5rem] h-[37.5rem] xl:flex-row xl:w-[35.2rem] xl:h-[26.8rem] 2xl:w-[39.6rem] 2xl:h-[30.15rem] 3xl:w-[44rem] 3xl:h-[33.5rem] ${variantClass}`}
       data-testid="photoDiv"
-      style={{
-        backgroundColor: backgroundColor,
-      }}
       aria-label={`Photo card with title: ${title}`}
     >
       <img
@@ -29,18 +32,16 @@ const PhotoCard = ({
         alt={title}
         className="cardImg object-cover h-[12.375rem] w-[21.5rem] xl:h-full xl:w-[20.6rem] 2xl:w-[23.175rem] 3xl:w-[25.75rem]"
         aria-label={`Image representing ${title}`}
-      ></img>
+      />
       <div className="flex flex-col justify-center p-6">
         <h3
           className="cardHeading relative text-headlineLarge xl:text-displaySmall 3xl:text-displayMedium font-barlow font-medium mb-7 mt-1 xl:mb-3 xl:mt-1 xl:mb-5 2xl:mb-6 xl:bottom-2 2xl:bottom-1 3xl:mb-7"
-          style={{ color: fontColor }}
-          aria-label={`Card title: ${isSmallScreen ? smallScreenTitle : title}`}
+          aria-label={`Card title: ${title}`}
         >
-          {isSmallScreen ? smallScreenTitle : title}
+          {title}
         </h3>
         <p
           className="cardDescription relative font-barlow text-bodyLarge xl:text-bodyMedium 2xl:text-bodyLarge font-regular mb-8 rounded xl:bottom-2 2xl:bottom-2 3xl:bottom-3"
-          style={{ color: fontColor }}
           aria-label={`Card description: ${description}`}
         >
           {description}
@@ -62,18 +63,17 @@ const PhotoCard = ({
 PhotoCard.propTypes = {
   imageUrl: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
-  smallScreenTitle: PropTypes.string,
   description: PropTypes.string.isRequired,
   buttonIcon: PropTypes.string,
   buttonLabel: PropTypes.string.isRequired,
-  backgroundColor: PropTypes.string.isRequired,
-  fontColor: PropTypes.string.isRequired,
   buttonVariant: PropTypes.string.isRequired,
   buttonTestId: PropTypes.string.isRequired,
+  cardVariant: PropTypes.oneOf(["variant1", "variant2"]),
 };
 
 PhotoCard.defaultProps = {
   buttonIcon: null,
+  cardVariant: "variant1", // Default variant
 };
 
 export default PhotoCard;

--- a/src/components/Card/PhotoCard.js
+++ b/src/components/Card/PhotoCard.js
@@ -22,50 +22,55 @@ const PhotoCard = ({
   const variantClass = VARIANT_CLASSES[cardVariant] || VARIANT_CLASSES.variant1; // Default to variant1
 
   return (
-    <div
-      className={`relative flex flex-col rounded-3xl overflow-hidden w-[21.5rem] h-[37.5rem] xl:flex-row xl:w-[35.2rem] xl:h-[26.8rem] 2xl:w-[39.6rem] 2xl:h-[30.15rem] 3xl:w-[44rem] 3xl:h-[33.5rem] ${variantClass}`}
-      data-testid="photoDiv"
-      aria-label={`Photo card with title: ${title}`}
+    <article
+      className={`relative flex flex-col rounded-[2rem] w-full h-auto sm:h-[33.5rem] sm:flex-row ${variantClass}`}
+      data-testid="photo-card"
+      aria-labelledby="photo-card-title"
+      aria-describedby="photo-card-description"
     >
-      <img
-        src={imageUrl}
-        alt={title}
-        className="object-cover h-[12.375rem] w-[21.5rem] xl:h-full xl:w-[20.6rem] 2xl:w-[23.175rem] 3xl:w-[25.75rem]"
-        data-testid="card-image"
-        aria-label={`Image representing ${title}`}
-      />
+      <figure
+        className={`overflow-hidden rounded-tl-[2rem] rounded-tr-[2rem] sm:rounded-tr-none sm:rounded-tl-[2rem] sm:rounded-bl-[2rem] w-full h-auto sm:h-[33.5rem] sm:flex-row ${variantClass}`}
+        data-testid="photo-card-image"
+        aria-labelledby="photo-card-title"
+      >
+        <img
+          src={imageUrl}
+          alt={title}
+          className="object-cover h-[12.375rem] w-[21.5rem] sm:h-[33.5rem] sm:w-[25.75rem]"
+          data-testid="card-image"
+          aria-label={`Image representing ${title}`}
+        />
+      </figure>
+
       <div
-        className="flex flex-col justify-center p-6"
-        data-testid="card-content"
+        className="flex flex-col justify-center gap-8 sm:p-6 sm:py-8 sm:w-[18.25rem]"
+        data-testid="photo-card-content"
       >
         <h3
-          className="relative text-headlineLarge xl:text-displaySmall 3xl:text-displayMedium font-barlow font-medium mb-7 mt-1 xl:mb-3 xl:mt-1 xl:mb-5 2xl:mb-6 xl:bottom-2 2xl:bottom-1 3xl:mb-7"
-          data-testid="card-title"
+          className="text-displaySmall font-barlow font-medium justify-center"
+          id="photo-card-title"
+          data-testid="photo-card-title"
           aria-label={`Card title: ${title}`}
         >
           {title}
         </h3>
         <p
-          className="relative font-barlow text-bodyLarge xl:text-bodyMedium 2xl:text-bodyLarge font-regular mb-8 rounded xl:bottom-2 2xl:bottom-2 3xl:bottom-3"
-          data-testid="card-description"
+          className="relative font-barlow text-bodyLarge sm:text-bodyMedium"
+          id="photo-card-description"
+          data-testid="photo-card-description"
           aria-label={`Card description: ${description}`}
         >
           {description}
         </p>
-        <div
-          className="absolute bottom-10 left-1/2 transform -translate-x-1/2 flex justify-center items-center mt-2 xl:mt-0 xl:bottom-7 xl:left-auto xl:translate-x-0 xl:justify-start xl:ml-1 2xl:bottom-8 3xl:bottom-8"
-          data-testid="card-button-container"
-        >
-          <Button
-            text={buttonLabel}
-            icon={buttonIcon}
-            variant={buttonVariant}
-            testId={buttonTestId}
-            ariaLabel={buttonLabel}
-          />
-        </div>
+        <Button
+          text={buttonLabel}
+          icon={buttonIcon}
+          variant={buttonVariant}
+          testId={buttonTestId}
+          ariaLabel={buttonLabel}
+        />
       </div>
-    </div>
+    </article>
   );
 };
 

--- a/src/components/ContentGrid/PhotoCardsWineTasting.js
+++ b/src/components/ContentGrid/PhotoCardsWineTasting.js
@@ -6,7 +6,7 @@ import PhotoCard from "../Card/PhotoCard";
 const PhotoCardsWineTasting = () => {
   return (
     <div
-      className="grid grid-col-1 md:grid-cols-2 w-full justify-center items-center gap-2 "
+      className="grid grid-col-1 sm:grid-cols-2 w-full justify-center items-center gap-2 "
       data-testid="photo-cards-wine-tasting"
     >
       <PhotoCard

--- a/src/components/ContentGrid/PhotoCardsWineTasting.js
+++ b/src/components/ContentGrid/PhotoCardsWineTasting.js
@@ -6,38 +6,27 @@ import PhotoCard from "../Card/PhotoCard";
 const PhotoCardsWineTasting = () => {
   return (
     <div
-      className="flex w-full justify-center items-center"
+      className="grid grid-col-1 md:grid-cols-2 w-full justify-center items-center gap-2 "
       data-testid="photo-cards-wine-tasting"
     >
-      <div
-        data-testid="testGrid"
-        className="grid-cols-1 grid gap-4 p-4 md:grid-cols-2 mt-2 xl:mt-4 -mb-4 xl:mb-0"
-      >
-        <PhotoCard
-          imageUrl="/images/card-unsplash-wine-tasting.jpg"
-          title="Wine tasting with dinner"
-          smallScreenTitle="Wine tasting with dinner"
-          description="Experience an unforgettable Italian wine dinner guided by sommelier Katrine Giorgio. Discover rare wines paired with antipasti, pasta, and dessert prepared by our chef Riccardo Lara."
-          buttonIcon="/icons/calender-alt-1-gray.svg"
-          buttonLabel="Book in the shop"
-          backgroundColor="#E0E0E0"
-          fontColor="#101010"
-          buttonVariant="primary"
-          buttonTestId="book-in-shop-button"
-        />
-        <PhotoCard
-          imageUrl="/images/card-unsplash-wine-table.jpg"
-          title="Wine tasting with dinner for companies"
-          smallScreenTitle="Wine tasting with dinner for companies"
-          description="Strengthen team bonds with a tailored Italian wine tasting experience. Perfect for team building, networking, or a relaxing evening with dinner."
-          buttonIcon="/icons/phone.svg"
-          buttonLabel="Contact us"
-          backgroundColor="#183F27"
-          fontColor="#E8ECE9"
-          buttonVariant="secondary-darker"
-          buttonTestId="contact-us-button"
-        />
-      </div>
+      <PhotoCard
+        imageUrl="/images/card-unsplash-wine-tasting.jpg"
+        title="Wine tasting with dinner"
+        description="Experience an unforgettable Italian wine dinner guided by sommelier Katrine Giorgio. Discover rare wines paired with antipasti, pasta, and dessert prepared by our chef Riccardo Lara."
+        buttonIcon="/icons/calender-alt-1-gray.svg"
+        buttonLabel="Book in the shop"
+        buttonVariant="secondary-darker"
+        buttonTestId="book-in-shop-button"
+      />
+      <PhotoCard
+        imageUrl="/images/card-unsplash-wine-table.jpg"
+        title="Wine tasting with dinner for companies"
+        description="Strengthen team bonds with a tailored Italian wine tasting experience. Perfect for team building, networking, or a relaxing evening with dinner."
+        buttonIcon="/icons/phone.svg"
+        buttonLabel="Contact us"
+        buttonVariant="secondary-light"
+        buttonTestId="contact-us-button"
+      />
     </div>
   );
 };

--- a/src/components/ContentGrid/PhotoCardsWineTasting.js
+++ b/src/components/ContentGrid/PhotoCardsWineTasting.js
@@ -6,7 +6,7 @@ import PhotoCard from "../Card/PhotoCard";
 const PhotoCardsWineTasting = () => {
   return (
     <div
-      className="grid grid-col-1 sm:grid-cols-2 w-full justify-center items-center gap-2 "
+      className="grid grid-col-1 sm:grid-cols-2 w-full justify-center items-center gap-2"
       data-testid="photo-cards-wine-tasting"
     >
       <PhotoCard
@@ -17,6 +17,7 @@ const PhotoCardsWineTasting = () => {
         buttonLabel="Book in the shop"
         buttonVariant="secondary-darker"
         buttonTestId="book-in-shop-button"
+        cardVariant="variant1"
       />
       <PhotoCard
         imageUrl="/images/card-unsplash-wine-table.jpg"
@@ -26,6 +27,7 @@ const PhotoCardsWineTasting = () => {
         buttonLabel="Contact us"
         buttonVariant="secondary-light"
         buttonTestId="contact-us-button"
+        cardVariant="variant2"
       />
     </div>
   );

--- a/src/components/ContentGrid/PhotoCardsWineTasting.js
+++ b/src/components/ContentGrid/PhotoCardsWineTasting.js
@@ -6,7 +6,7 @@ import PhotoCard from "../Card/PhotoCard";
 const PhotoCardsWineTasting = () => {
   return (
     <div
-      className="grid grid-col-1 sm:grid-cols-2 w-full justify-center items-center gap-2"
+      className="grid grid-col-1 sm:grid-cols-2 w-full justify-center items-center gap-2 place-items-center"
       data-testid="photo-cards-wine-tasting"
     >
       <PhotoCard

--- a/src/components/ContentGrid/PhotoCardsWineTasting.js
+++ b/src/components/ContentGrid/PhotoCardsWineTasting.js
@@ -6,7 +6,7 @@ import PhotoCard from "../Card/PhotoCard";
 const PhotoCardsWineTasting = () => {
   return (
     <div
-      className="grid grid-col-1 sm:grid-cols-2 w-full justify-center items-center gap-2 place-items-center"
+      className="grid grid-col-1 sm:grid-cols-2 w-full justify-center items-center gap-2 px-2 sm:p-2 place-items-center"
       data-testid="photo-cards-wine-tasting"
     >
       <PhotoCard

--- a/src/components/ContentGrid/PhotoCardsWineTasting.js
+++ b/src/components/ContentGrid/PhotoCardsWineTasting.js
@@ -15,53 +15,27 @@ const PhotoCardsWineTasting = () => {
       >
         <PhotoCard
           imageUrl="/images/card-unsplash-wine-tasting.jpg"
-          title={
-            <span>
-              Wine
-              <br />
-              tasting with dinner
-            </span>
-          }
-          smallScreenTitle={
-            <span>
-              Wine tasting with
-              <br />
-              dinner
-            </span>
-          }
+          title="Wine tasting with dinner"
+          smallScreenTitle="Wine tasting with dinner"
           description="Experience an unforgettable Italian wine dinner guided by sommelier Katrine Giorgio. Discover rare wines paired with antipasti, pasta, and dessert prepared by our chef Riccardo Lara."
           buttonIcon="/icons/calender-alt-1-gray.svg"
           buttonLabel="Book in the shop"
           backgroundColor="#E0E0E0"
           fontColor="#101010"
-          buttonBgColor="#2f2e2e"
-          buttonFontColor="#ffffff"
+          buttonVariant="primary"
+          buttonTestId="book-in-shop-button"
         />
         <PhotoCard
           imageUrl="/images/card-unsplash-wine-table.jpg"
-          title={
-            <span>
-              Wine
-              <br />
-              tasting with dinner for companies
-            </span>
-          }
-          smallScreenTitle={
-            <span>
-              Wine tasting with
-              <br />
-              dinner for
-              <br />
-              companies
-            </span>
-          }
+          title="Wine tasting with dinner for companies"
+          smallScreenTitle="Wine tasting with dinner for companies"
           description="Strengthen team bonds with a tailored Italian wine tasting experience. Perfect for team building, networking, or a relaxing evening with dinner."
           buttonIcon="/icons/phone.svg"
           buttonLabel="Contact us"
           backgroundColor="#183F27"
           fontColor="#E8ECE9"
-          buttonBgColor="#E8ECE9"
-          buttonFontColor="#08160E"
+          buttonVariant="secondary-darker"
+          buttonTestId="contact-us-button"
         />
       </div>
     </div>


### PR DESCRIPTION
### Summary:  
The original goal was to fix padding and button usage, but during the review, it became clear that some properties, like background and font colors, were directly defined instead of leveraging the centralized TailwindCSS configuration. To improve flexibility and maintainability, I refactored both components, focusing on the following:  

- **Centralized Styling:** Replaced hardcoded colors with a `cardVariant` prop to dynamically apply predefined TailwindCSS classes.  
- **Improved Semantics:** Simplified structure to make components more intuitive and accessible.  
- **Test Simplification:** Streamlined tests to focus on unit-level validation, ensuring alignment with the refactored structure.  
- **Removed Redundancies:** Eliminated unused or redundant props (`backgroundColor`, `fontColor`, `smallScreenTitle`) to adhere to DRY principles and simplify logic.  

These changes were made to align with TailwindCSS best practices and improve the overall maintainability and flexibility of the codebase, while respecting the solid foundation already in place. 

![Captura de Pantalla 2025-01-12 a la(s) 17 13 14](https://github.com/user-attachments/assets/4dc9069c-d338-4d67-b8f0-beea064e1fd1)
![Captura de Pantalla 2025-01-12 a la(s) 17 15 19](https://github.com/user-attachments/assets/9792899e-86f4-4db7-b4f7-b5e226994f4c)
![Captura de Pantalla 2025-01-12 a la(s) 17 15 12](https://github.com/user-attachments/assets/32fb561a-7afa-4e84-b04b-3745afccda46)

Additional Note:
In the next pull request, I will focus on refactoring the remaining two card components to align with the improvements made here. This will ensure consistency across all cards and further enhance maintainability and styling flexibility.

