### PR TITLE
Refactor: rename button varients

### DIFF
--- a/src/__tests__/componentsTest/Button.test.js
+++ b/src/__tests__/componentsTest/Button.test.js
@@ -23,16 +23,6 @@ describe("Button Component", () => {
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
 
-  it("should apply the correct class based on variant", () => {
-    const { container } = render(
-      <Button text="Visit our shop" variant="primary" />,
-    );
-    const button = container.querySelector("button");
-    expect(button).toHaveClass("bg-primary-normal");
-    expect(button).toHaveClass("text-primary-light");
-    expect(button).toHaveClass("bodyLarge");
-  });
-
   it("should disable the button when disabled is true", () => {
     render(<Button text="Visit our shop" disabled />);
     const button = screen.getByText(/Visit our shop/i);
@@ -51,44 +41,81 @@ describe("Button Component", () => {
     expect(button.type).toBe("submit");
   });
 
-  it("should apply the correct class for secondary variant", () => {
-    const { container } = render(
-      <Button text="Visit our shop" variant="secondary" />,
-    );
-    const button = container.querySelector("button");
-    expect(button).toHaveClass("bg-transparent");
-    expect(button).toHaveClass("border-2");
-    expect(button).toHaveClass("text-primary-active_normal");
-    expect(button).toHaveClass("bodyLarge");
-  });
+  const variantTests = [
+    {
+      variant: "red",
+      expectedClasses: [
+        "bg-primary-normal",
+        "hover:bg-primary-hover_normal",
+        "text-primary-light",
+        "w-full",
+        "sm:w-[10.8rem]",
+      ],
+    },
+    {
+      variant: "redLine",
+      expectedClasses: [
+        "bg-transparent",
+        "border-2",
+        "hover:bg-primary-hover",
+        "border-primary-active_normal",
+        "text-primary-active_normal",
+        "w-full",
+        "sm:w-[10.8rem]",
+      ],
+    },
+    {
+      variant: "darkGreen",
+      expectedClasses: [
+        "bg-secondary-darker",
+        "hover:bg-secondary-hover_dark",
+        "text-white",
+        "w-full",
+        "sm:w-[10.8rem]",
+      ],
+    },
+    {
+      variant: "grayGreen",
+      expectedClasses: [
+        "bg-secondary-light",
+        "hover:bg-secondary-hover",
+        "text-secondary-darker",
+        "w-full",
+        "sm:w-[10.8rem]",
+      ],
+    },
+    {
+      variant: "redSubmit",
+      expectedClasses: [
+        "bg-primary-normal",
+        "hover:bg-primary-hover_normal",
+        "text-white",
+        "rounded-lg",
+        "w-full",
+        "sm:w-[10.8rem]",
+      ],
+    },
+    {
+      variant: "gray",
+      expectedClasses: [
+        "bg-tertiary1-normal",
+        "hover:bg-tertiary1-dark",
+        "text-tertiary1-light",
+        "w-full",
+        "sm:w-[10.8rem]",
+      ],
+    },
+  ];
 
-  it("should apply the correct class for secondary-darker variant", () => {
-    const { container } = render(
-      <Button text="Visit our shop" variant="secondary-darker" />,
-    );
-    const button = container.querySelector("button");
-    expect(button).toHaveClass("bg-secondary-darker");
-    expect(button).toHaveClass("text-white");
-    expect(button).toHaveClass("bodyLarge");
-  });
-
-  it("should apply the correct class for secondary-light variant", () => {
-    const { container } = render(
-      <Button text="Visit our shop" variant="secondary-light" />,
-    );
-    const button = container.querySelector("button");
-    expect(button).toHaveClass("bg-secondary-light");
-    expect(button).toHaveClass("text-secondary-darker");
-    expect(button).toHaveClass("bodyLarge");
-  });
-
-  it("should apply the correct class for primary-submit variant", () => {
-    const { container } = render(
-      <Button text="Visit our shop" variant="primary-submit" />,
-    );
-    const button = container.querySelector("button");
-    expect(button).toHaveClass("bg-primary-normal");
-    expect(button).toHaveClass("text-white");
-    expect(button).toHaveClass("bodyLarge");
+  variantTests.forEach(({ variant, expectedClasses }) => {
+    it(`should apply the correct classes for ${variant} variant`, () => {
+      const { container } = render(
+        <Button text="Button Text" variant={variant} />,
+      );
+      const button = container.querySelector("button");
+      expectedClasses.forEach((className) => {
+        expect(button).toHaveClass(className);
+      });
+    });
   });
 });

--- a/src/app/our-team/page.js
+++ b/src/app/our-team/page.js
@@ -68,7 +68,7 @@ const OurTeam = () => {
           <Button
             text="Go back"
             icon="/icons/back-arrow.svg"
-            variant="secondary"
+            variant="darkGreen"
             ariaLabel="Go back"
             testId="go-back-button"
             onClick={() => {

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -3,6 +3,23 @@
 import React from "react";
 import PropTypes from "prop-types";
 
+const BASE_BUTTON_CLASSES = `
+  flex justify-center items-center h-[3rem] rounded-[0.3rem] bodyLarge
+`;
+
+const VARIANT_CLASSES = {
+  red: "bg-primary-normal hover:bg-primary-hover_normal text-primary-light w-full sm:w-[10.8rem]",
+  redLine:
+    "bg-transparent border-2 hover:bg-primary-hover border-primary-active_normal text-primary-active_normal w-full sm:w-[10.8rem]",
+  darkGreen:
+    "bg-secondary-darker hover:bg-secondary-hover_dark text-white w-full sm:w-[10.8rem]",
+  grayGreen:
+    "bg-secondary-light hover:bg-secondary-hover text-secondary-darker w-full sm:w-[10.8rem]",
+  redSubmit:
+    "bg-primary-normal hover:bg-primary-hover_normal text-white rounded-lg w-full sm:w-[10.8rem]",
+  gray: "bg-tertiary1-normal hover:bg-tertiary1-dark text-tertiary1-light w-full sm:w-[10.8rem]",
+};
+
 const Button = ({
   text,
   icon,
@@ -13,19 +30,11 @@ const Button = ({
   testId,
   isLoading = false,
 }) => {
-  const buttonClass = `flex justify-center items-center h-[3rem] rounded-[0.3rem] ${
-    variant === "primary"
-      ? "bg-primary-normal hover:bg-primary-hover_normal text-primary-light  bodyLarge w-full sm:w-[10.8rem] h-[3rem]"
-      : variant === "secondary"
-        ? "bg-transparent border-2 hover:bg-primary-hover border-primary-active_normal text-primary-active_normal bodyLarge w-full sm:w-[10.8rem] h-[3rem]"
-        : variant === "secondary-darker"
-          ? "bg-secondary-darker hover:bg-secondary-hover_dark text-white bodyLarge w-full sm:w-[10.8rem] h-[3rem]"
-          : variant === "secondary-light"
-            ? "bg-secondary-light hover:bg-secondary-hover text-secondary-darker bodyLarge w-full sm:w-[10.8rem] h-[3rem]"
-            : variant === "primary-submit"
-              ? "bg-primary-normal hover:bg-primary-hover_normal text-white rounded-lg bodyLarge w-full sm:w-[10.8rem] h-[3rem]"
-              : ""
-  } ${disabled || isLoading ? "opacity-50 cursor-not-allowed" : ""}`;
+  const buttonClass = `
+  ${BASE_BUTTON_CLASSES}
+  ${VARIANT_CLASSES[variant] || ""}
+  ${disabled || isLoading ? "opacity-50 cursor-not-allowed" : ""}
+`.trim();
 
   return (
     <button
@@ -52,11 +61,12 @@ Button.propTypes = {
   text: PropTypes.string.isRequired,
   icon: PropTypes.string,
   variant: PropTypes.oneOf([
-    "primary",
-    "secondary",
-    "secondary-darker",
-    "secondary-light",
-    "primary-submit",
+    "red",
+    "redLine",
+    "darkGreen",
+    "grayGreen",
+    "redSubmit",
+    "gray",
   ]),
   onClick: PropTypes.func,
   disabled: PropTypes.bool,

--- a/src/components/Card/PhotoCardSmaller.js
+++ b/src/components/Card/PhotoCardSmaller.js
@@ -45,7 +45,8 @@ const PhotoCardSmaller = ({
         >
           {description}
         </p>
-        <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 flex justify-center items-center mt-2 xl:mt-0 xl:bottom-11 xl:left-auto xl:translate-x-0 xl:justify-start 2xl:bottom-12 3xl:bottom-16">
+        {/* <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 flex justify-center items-center mt-2 xl:mt-0 xl:bottom-11 xl:left-auto xl:translate-x-0 xl:justify-start 2xl:bottom-12 3xl:bottom-16"> */}
+        <div className="flex justify-center items-center">
           <Button
             text={buttonLabel}
             icon={buttonIconUrl}

--- a/src/components/ContentGrid/PhotoCardsTeamValues.js
+++ b/src/components/ContentGrid/PhotoCardsTeamValues.js
@@ -16,7 +16,7 @@ const PhotoCardsTeamValues = () => {
           backgroundColor="#183F27"
           buttonIconUrl="/icons/team.svg"
           buttonLabel="Read More"
-          buttonVariant="secondary-light"
+          buttonVariant="grayGreen"
           buttonTestId="read-more-button-team"
         />
         <PhotoCardSmaller
@@ -27,7 +27,7 @@ const PhotoCardsTeamValues = () => {
           backgroundColor="#E0E0E0"
           buttonIconUrl="/icons/diamond-alt.svg"
           buttonLabel="Read More"
-          buttonVariant="secondary-darker"
+          buttonVariant="darkGreen"
           buttonTestId="read-more-button-values"
         />
       </div>

--- a/src/components/HeroSection/HeroSection.js
+++ b/src/components/HeroSection/HeroSection.js
@@ -50,7 +50,7 @@ const HeroSection = () => {
             <Button
               text="Visit Our Shop"
               icon="/icons/cart.svg"
-              variant="primary"
+              variant="red"
               ariaLabel="Visit our shop"
               testId="get-started-button"
             />
@@ -58,7 +58,7 @@ const HeroSection = () => {
             <Button
               text="Contact Us"
               icon="/icons/speech-bubble-19.svg"
-              variant="secondary"
+              variant="redLine"
               ariaLabel="Contact us"
               testId="secondary-button"
             />

--- a/src/components/Map/MapSection.js
+++ b/src/components/Map/MapSection.js
@@ -1,5 +1,6 @@
 "use client";
 import React from "react";
+import Button from "../Button/Button";
 
 const MapSection = () => {
   const locationUrl =
@@ -25,7 +26,7 @@ const MapSection = () => {
 
   return (
     <div
-      className="flex md:m-6 m-2 flex-col lg:flex-row bg-tertiary1-hover max-w-full md:rounded-[32px] rounded-[32px]"
+      className="flex md:m-6 m-2 flex-col md:flex-row bg-tertiary1-hover max-w-full md:rounded-[32px] rounded-[32px]"
       data-testid="map-section"
     >
       <div className="flex-1 md:rounded-[32px] rounded-none w-full">
@@ -66,13 +67,14 @@ const MapSection = () => {
               </div>
             </div>
           ))}
-          <button
-            aria-label="Check our location on Google Maps"
-            className="bg-tertiary1-normal text-tertiary1-light text-titleMedium rounded-[5px] py-3 px-6 flex items-center justify-center md:w-auto w-full"
-          >
-            <img src="/icons/map.svg" alt="" className="w-5 h-5 mr-2" />
-            Check on Maps
-          </button>
+          <Button
+            text={"Check on Maps"}
+            icon="/icons/map.svg"
+            onClick={() => {}}
+            variant="gray"
+            ariaLabel="Check our location on Google Maps"
+            testId="submit-button"
+          />
         </div>
       </div>
     </div>

--- a/src/components/OurValues/OurValues.js
+++ b/src/components/OurValues/OurValues.js
@@ -10,7 +10,7 @@ const OurValues = () => {
         <Button
           text="Go back"
           icon="/icons/back-arrow.svg"
-          variant="secondary"
+          variant="darkGreen"
           ariaLabel="Go back"
           testId="go-back-button"
         />

--- a/src/components/Subscribe/Subscribe.js
+++ b/src/components/Subscribe/Subscribe.js
@@ -57,7 +57,7 @@ const Subscribe = () => {
 
               <Button
                 text={isLoading ? "Submitting..." : "Submit"}
-                variant="primary-submit"
+                variant="redSubmit"
                 isLoading={isLoading}
                 onClick={handleSubmit}
                 disabled={isLoading}


### PR DESCRIPTION
### Rename varients in Button.js. Here's the usage example:

![image](https://github.com/user-attachments/assets/4af05647-aaf4-4c8c-a91f-8e11e85aa608)
