### PR TITLE
Feature/Reversal of the order of the links in the footer

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -6,22 +6,14 @@ import { useLanguage } from "@/app/context/LanguageContext";
 
 const Footer = () => {
   const { translations } = useLanguage();
-  const navLinks = [
-    {
-      id: "our-values",
-      href: "/our-values",
-      label: translations["footer.values"],
-    },
-    { id: "our-team", href: "/our-team", label: translations["footer.team"] },
-    { id: "contact", href: "/contact", label: translations["footer.contact"] },
-  ];
+
   return (
     <footer
       className="flex text-white text-center py-4 h-96 bg-[#2F2E2E] md:h-[26.625rem] items-start justify-center"
       data-testid="footer"
       aria-label="Footer"
     >
-      <div className="grid grid-cols-1 relative top-2 gap-1 md:top-0 md:grid-cols-5 md:mt-24 md:gap-5 lg:gap-8 xl:gap-11 ">
+      <div className="grid grid-cols-1 relative top-2 gap-1 md:top-0 md:grid-cols-5 md:mt-24 md:gap-5 lg:gap-8 xl:gap-11">
         <Link href="/" className="navbar-brand" aria-label="logo">
           <img
             className="h-20 rounded relative mt-4 mb-4 md:mt-0 md:mb-0 md:right-4"
@@ -30,19 +22,37 @@ const Footer = () => {
             data-testid="logo-footer"
           ></img>
         </Link>
-        {navLinks.map((link) => (
-          <Link
-            data-testid={link.id}
-            key={link.label}
-            href={link.href}
-            className="rounded-md px-3 py-2 text-bodyLarge text-semibold"
-            role="navigation"
-            aria-label={`Link to ${link.label}`}
-          >
-            {link.label}
-          </Link>
-        ))}
-        <div className="p-2">
+        <Link
+          data-testid={"our-team"}
+          label={translations["footer.team"]}
+          href="/our-team"
+          className="rounded-md px-3 py-2 text-bodyLarge text-semibold order-4 md:order-1"
+          role="navigation"
+          aria-label={`Link to ${translations["footer.team"]}`}
+        >
+          {translations["footer.team"]}
+        </Link>
+        <Link
+          data-testid={"our-values"}
+          label={translations["footer.values"]}
+          href="/our-values"
+          className="rounded-md px-3 py-2 text-bodyLarge text-semibold order-3 md:order-2"
+          role="navigation"
+          aria-label={`Link to ${translations["footer.values"]}`}
+        >
+          {translations["footer.values"]}
+        </Link>
+        <Link
+          data-testid={"contact"}
+          label={translations["footer.contact"]}
+          href="/contact"
+          className="rounded-md px-3 py-2 text-bodyLarge text-semibold order-2 md:order-3"
+          role="navigation"
+          aria-label={`Link to ${translations["footer.contact"]}`}
+        >
+          {translations["footer.contact"]}
+        </Link>
+        <div className="p-2 order-1 md:order-4">
           <h4 className="pb-3 text-bodyLarge text-semibold">
             {translations["footer.follow"]}
           </h4>

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -9,14 +9,14 @@ const Footer = () => {
 
   return (
     <footer
-      className="flex text-white text-center py-4 h-96 bg-[#2F2E2E] md:h-[26.625rem] items-start justify-center"
+      className="flex text-white text-center py-4 h-96 bg-[#2F2E2E] md:h-[26.625rem] items-center justify-center"
       data-testid="footer"
       aria-label="Footer"
     >
-      <div className="grid grid-cols-1 relative top-2 gap-1 md:top-0 md:grid-cols-5 md:mt-24 md:gap-5 lg:gap-8 xl:gap-11">
+      <div className="flex flex-col relative items-center gap-1 bottom-3 md:mb-32 md:flex-row md:gap-6 lg:gap-9 xl:gap-12">
         <Link href="/" className="navbar-brand" aria-label="logo">
           <img
-            className="h-[5.351rem] w-[7.75rem] rounded relative mt-4 mb-4 md:mt-0 md:mb-0 md:right-4"
+            className="h-[5.351rem] w-[7.75rem] rounded relative mt-6 mb-4 md:mt-0 md:mb-0 md:right-4 md:top-6"
             src="/images/donna-vino-logo-transparent.png"
             alt="Donna Vino Logo - Red background, white text saying 'Donna Vino'"
             data-testid="logo-footer"
@@ -52,12 +52,12 @@ const Footer = () => {
         >
           {translations["footer.contact"]}
         </Link>
-        <div className="p-2 order-1 md:order-4">
-          <h4 className="pb-2 md:pb-3 text-bodyLarge text-semibold">
+        <div className="flex flex-col order-1 md:order-4 items-center md:relative md:top-5">
+          <h4 className="text-bodyLarge text-semibold mb-1 md:mb-3 md:mt-3">
             {translations["footer.follow"]}
           </h4>
           <div
-            className="flex gap-4 ml-3 mt-3 relative right-1"
+            className="flex gap-4 justify-center mt-3 mb-1"
             aria-label="Social media icons"
           >
             <a

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -16,7 +16,7 @@ const Footer = () => {
       <div className="grid grid-cols-1 relative top-2 gap-1 md:top-0 md:grid-cols-5 md:mt-24 md:gap-5 lg:gap-8 xl:gap-11">
         <Link href="/" className="navbar-brand" aria-label="logo">
           <img
-            className="h-20 rounded relative mt-4 mb-4 md:mt-0 md:mb-0 md:right-4"
+            className="h-[5.351rem] w-[7.75rem] rounded relative mt-4 mb-4 md:mt-0 md:mb-0 md:right-4"
             src="/images/donna-vino-logo-transparent.png"
             alt="Donna Vino Logo - Red background, white text saying 'Donna Vino'"
             data-testid="logo-footer"
@@ -53,7 +53,7 @@ const Footer = () => {
           {translations["footer.contact"]}
         </Link>
         <div className="p-2 order-1 md:order-4">
-          <h4 className="pb-3 text-bodyLarge text-semibold">
+          <h4 className="pb-2 md:pb-3 text-bodyLarge text-semibold">
             {translations["footer.follow"]}
           </h4>
           <div
@@ -67,7 +67,7 @@ const Footer = () => {
               <img
                 src="/icons/footer/facebook-line.svg"
                 alt="Facebook Logo"
-                className="h-4 filter brightness-0 invert"
+                className="h-[1.5rem] w-[1.5rem] filter brightness-0 invert"
               ></img>
             </a>
             <a
@@ -77,14 +77,14 @@ const Footer = () => {
               <img
                 src="/icons/footer/instagram-original.svg"
                 alt="Instagram Logo"
-                className="h-4 filter brightness-0 invert"
+                className="h-[1.5rem] w-[1.5rem] filter brightness-0 invert"
               ></img>
             </a>
             <a href="/icons/footer/linkedin-alt.svg" className="text-white">
               <img
                 src="/icons/footer/linkedin-alt.svg"
                 alt="LinkedIn Logo"
-                className="h-4 filter brightness-0 invert"
+                className="h-[1.5rem] w-[1.5rem] filter brightness-0 invert"
               ></img>
             </a>
           </div>


### PR DESCRIPTION
# Reversal of the order of links in the footer

In order to align closer with the figma design, the footer links were reversed in order. A slight change was made in the code (moving away from using a const with all the necessary link-info, and using the map-function to cycle through this data when creating the links) to instead render the links in a regular fashion. This facilitated the use of the order-class for reversing the order of the individual links in the mobile version, as well as modifying the order above md screensizes. This approach will make it easier to change the specific order of the links if the design changes in the future.

## Preview:
footer at larger screens
![footer-large](https://github.com/user-attachments/assets/5f28ad7e-a704-4030-bf30-517934a3e64b)

footer below md
![footer-small](https://github.com/user-attachments/assets/7f143452-829a-47a2-87fd-7d8c5ed7024e)
