### PR TITLE
Feature/thematic cards responsivity and refactor

### DIFF
--- a/src/__tests__/componentsTest/ThematicCard.test.js
+++ b/src/__tests__/componentsTest/ThematicCard.test.js
@@ -14,12 +14,11 @@ import enTranslations from "../../translations/en.json";
 describe("ThematicCard Component", () => {
   const defaultProps = {
     imageUrl: "/test-image.jpg",
-    imgPos: "left",
+    cardVariant: "variant1",
     smallCardSize: "medium",
     title: "Test Title",
     descriptionStart: "This is the start of the description.",
     descriptionEnd: "This is the end of the description.",
-    backgroundColor: "#ffffff",
   };
 
   // Mock the screen size adjustment for small screens

--- a/src/components/Card/ThematicCard.js
+++ b/src/components/Card/ThematicCard.js
@@ -74,7 +74,7 @@ const ThematicCard = ({
       ></img>
       <div className="flex flex-col justify-center p-6 lg:pl-4 lg:pr-12 xl:pl-6 xl:pr-10 2xl:pl-8 2xl:pr-20">
         <h3
-          className="text-displaySmall text-tertiary1-darker relative font-roboto mb-5 lg:mb-4 lg:-mt-1 lg:text-headlineMedium xl:text-headlineLarge" // 3xl:mt-1 3xl:mb-2
+          className="text-displaySmall text-tertiary1-darker relative font-roboto mb-5 lg:mb-4 lg:-mt-1 lg:text-headlineMedium xl:text-headlineLarge"
           aria-label={`Card title: ${title}`}
         >
           {title}

--- a/src/components/Card/ThematicCard.js
+++ b/src/components/Card/ThematicCard.js
@@ -50,22 +50,18 @@ const ThematicCard = ({
         expanded
           ? smallCardSize === "small"
             ? "h-[52.25rem]"
-            : smallCardSize === "small2"
-              ? "h-[52.25rem]"
-              : smallCardSize === "medium"
-                ? "h-[49.75rem]"
-                : smallCardSize === "big"
-                  ? "h-[58.5rem]"
-                  : "h-[49.75rem]" // Default height if no conditions match
+            : smallCardSize === "medium"
+              ? "h-[49.75rem]"
+              : smallCardSize === "big"
+                ? "h-[58.5rem]"
+                : "h-[49.75rem]" // Default height if no conditions match
           : smallCardSize === "small"
             ? "h-[30.75rem]"
-            : smallCardSize === "small2"
-              ? "h-[30.75rem]"
-              : smallCardSize === "medium"
+            : smallCardSize === "medium"
+              ? "h-[33.5rem]"
+              : smallCardSize === "big"
                 ? "h-[33.5rem]"
-                : smallCardSize === "big"
-                  ? "h-[33.5rem]"
-                  : "h-[33.5rem]" // Default height if not expanded
+                : "h-[33.5rem]" // Default height if not expanded
       } lg:h-[18.5rem] lg:w-auto lg:ml-1 lg:mr-1 lg:mb-2 ${variantClass}`}
       data-testid="thematicDiv"
       // style={{

--- a/src/components/Card/ThematicCard.js
+++ b/src/components/Card/ThematicCard.js
@@ -8,8 +8,8 @@ const VARIANT_CLASSES = {
 };
 
 const VARIANT_CLASSES_ORDER = {
-  variant1: "lg:order-0",
-  variant2: "lg:order-1",
+  variant1: "lg:order-0 lg:rounded-l-3xl",
+  variant2: "lg:order-1 lg:rounded-r-3xl",
 };
 
 const ThematicCard = ({
@@ -54,25 +54,22 @@ const ThematicCard = ({
               ? "h-[49.75rem]"
               : smallCardSize === "big"
                 ? "h-[58.5rem]"
-                : "h-[49.75rem]" // Default height if no conditions match
+                : "h-[49.75rem]"
           : smallCardSize === "small"
             ? "h-[30.75rem]"
             : smallCardSize === "medium"
               ? "h-[33.5rem]"
               : smallCardSize === "big"
                 ? "h-[33.5rem]"
-                : "h-[33.5rem]" // Default height if not expanded
+                : "h-[33.5rem]"
       } lg:h-[18.5rem] lg:w-auto lg:ml-1 lg:mr-1 lg:mb-2 ${variantClass}`}
       data-testid="thematicDiv"
-      // style={{
-      //   backgroundColor: backgroundColor,
-      // }}
       aria-label={`Thematic card with title: ${title}`}
     >
       <img
         src={imageUrl}
         alt={title}
-        className={`object-cover h-[12.375rem] w-[21.5rem] lg:w-[25.75rem] lg:h-[18.5rem] ${variantClassOrder}`}
+        className={`object-cover h-[12.375rem] w-[21.5rem] lg:w-[25.75rem] lg:h-[19.5rem] ${variantClassOrder}`}
         aria-label={`Image representing ${title}`}
       ></img>
       <div className="flex flex-col justify-center p-6 lg:pl-4 lg:pr-12 xl:pl-6 xl:pr-10 2xl:pl-8 2xl:pr-20">

--- a/src/components/Card/ThematicCard.js
+++ b/src/components/Card/ThematicCard.js
@@ -46,7 +46,7 @@ const ThematicCard = ({
   const { translations } = useLanguage();
   return (
     <div
-      className={`relative flex flex-col lg:flex-row rounded-3xl overflow-hidden shadow-md mb-1 w-[21.5rem] transition-all duration-300 ${
+      className={`relative flex flex-col gap-2 lg:flex-row rounded-3xl overflow-hidden shadow-md mb-1 w-[21.5rem] transition-all duration-300 ${
         expanded
           ? smallCardSize === "small"
             ? "h-[52.25rem]"
@@ -79,9 +79,9 @@ const ThematicCard = ({
         className={`object-cover h-[12.375rem] w-[21.5rem] lg:w-[25.75rem] lg:h-[18.5rem] ${variantClassOrder}`}
         aria-label={`Image representing ${title}`}
       ></img>
-      <div className="flex flex-col justifycenter p-6 lg:pr-12 xl:pr-10 2xl:pr-20">
+      <div className="flex flex-col justify-center p-6 lg:pl-4 lg:pr-12 xl:pl-6 xl:pr-10 2xl:pl-8 2xl:pr-20">
         <h3
-          className="text-displaySmall text-tertiary1-darker relative font-roboto mb-6 mt-2 lg:mt-3 lg:mb-5 lg:text-headlineMedium xl:mt-2 2xl:mt-5 2xl:mb-7 xl:text-headlineLarge" // 3xl:mt-1 3xl:mb-2
+          className="text-displaySmall text-tertiary1-darker relative font-roboto mb-5 lg:mb-4 lg:-mt-1 lg:text-headlineMedium xl:text-headlineLarge" // 3xl:mt-1 3xl:mb-2
           aria-label={`Card title: ${title}`}
         >
           {title}

--- a/src/components/Card/ThematicCard.js
+++ b/src/components/Card/ThematicCard.js
@@ -2,15 +2,27 @@ import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { useLanguage } from "@/app/context/LanguageContext";
 
+const VARIANT_CLASSES = {
+  variant1: "bg-secondary-active",
+  variant2: "bg-secondary-light",
+};
+
+const VARIANT_CLASSES_ORDER = {
+  variant1: "lg:order-0",
+  variant2: "lg:order-1",
+};
+
 const ThematicCard = ({
   imageUrl,
-  imgPos,
+  cardVariant,
   smallCardSize,
   title,
   descriptionStart,
   descriptionEnd,
-  backgroundColor,
 }) => {
+  const variantClass = VARIANT_CLASSES[cardVariant] || VARIANT_CLASSES.variant1; // Default to variant1
+  const variantClassOrder =
+    VARIANT_CLASSES_ORDER[cardVariant] || VARIANT_CLASSES_ORDER.variant1; // Default to variant1
   const [expanded, setExpanded] = useState(false);
   const [isSmallScreen, setIsSmallScreen] = useState(true);
 
@@ -34,12 +46,12 @@ const ThematicCard = ({
   const { translations } = useLanguage();
   return (
     <div
-      className={`thematicDiv relative flex flex-col lg:flex-row rounded-3xl overflow-hidden shadow-md mb-1 w-[21.5rem] transition-all duration-300 ${
+      className={`relative flex flex-col lg:flex-row rounded-3xl overflow-hidden shadow-md mb-1 w-[21.5rem] transition-all duration-300 ${
         expanded
           ? smallCardSize === "small"
-            ? "h-[51.25rem]"
+            ? "h-[52.25rem]"
             : smallCardSize === "small2"
-              ? "h-[52.5rem]"
+              ? "h-[52.25rem]"
               : smallCardSize === "medium"
                 ? "h-[49.75rem]"
                 : smallCardSize === "big"
@@ -54,22 +66,22 @@ const ThematicCard = ({
                 : smallCardSize === "big"
                   ? "h-[33.5rem]"
                   : "h-[33.5rem]" // Default height if not expanded
-      } lg:h-[18.5rem] lg:w-auto lg:ml-1 lg:mr-1 lg:mb-2`}
+      } lg:h-[18.5rem] lg:w-auto lg:ml-1 lg:mr-1 lg:mb-2 ${variantClass}`}
       data-testid="thematicDiv"
-      style={{
-        backgroundColor: backgroundColor,
-      }}
+      // style={{
+      //   backgroundColor: backgroundColor,
+      // }}
       aria-label={`Thematic card with title: ${title}`}
     >
       <img
         src={imageUrl}
         alt={title}
-        className={`cardImg object-cover h-[12.375rem] w-[21.5rem] lg:w-[25.75rem] lg:h-[18.5rem] ${imgPos == "right" ? "lg:order-1" : "lg:order-0"}`}
+        className={`object-cover h-[12.375rem] w-[21.5rem] lg:w-[25.75rem] lg:h-[18.5rem] ${variantClassOrder}`}
         aria-label={`Image representing ${title}`}
       ></img>
       <div className="flex flex-col justifycenter p-6 lg:pr-12 xl:pr-10 2xl:pr-20">
         <h3
-          className="text-displaySmall text-tertiary1-darker relative font-roboto mb-6 mt-2 lg:mt-4 lg:mb-5 lg:text-headlineMedium xl:mt-6 xl:text-headlineLarge" // 3xl:mt-1 3xl:mb-2
+          className="text-displaySmall text-tertiary1-darker relative font-roboto mb-6 mt-2 lg:mt-3 lg:mb-5 lg:text-headlineMedium xl:mt-2 2xl:mt-5 2xl:mb-7 xl:text-headlineLarge" // 3xl:mt-1 3xl:mb-2
           aria-label={`Card title: ${title}`}
         >
           {title}
@@ -89,7 +101,7 @@ const ThematicCard = ({
         {isSmallScreen && (
           <button
             onClick={() => setExpanded(!expanded)}
-            className={`mx-auto mt-6 lg-hidden relative top-1`}
+            className={`mx-auto mt-auto py-2 px-4 self-center ${expanded ? "py-6" : "py-9"} lg-hidden`}
             data-testid="thematic-button"
           >
             {expanded ? (
@@ -117,12 +129,11 @@ const ThematicCard = ({
 // Prop validation
 ThematicCard.propTypes = {
   imageUrl: PropTypes.string.isRequired, // Image URL must be a string and is required
-  imgPos: PropTypes.string.isRequired, // Image Position must be a string and is required
+  cardVariant: PropTypes.string.isRequired, // Card Variant must be a string and is required
   smallCardSize: PropTypes.string.isRequired, // Small card size must be a string and is required
   title: PropTypes.string.isRequired, // Title must be a string and is required
   descriptionStart: PropTypes.string.isRequired, // Description-start must be a string and is required
   descriptionEnd: PropTypes.string.isRequired, // Description-end must be a string and is required
-  backgroundColor: PropTypes.string.isRequired, // Background color must be a string and is required
 };
 
 export default ThematicCard;

--- a/src/components/ContentGrid/ThematicCardsValues.js
+++ b/src/components/ContentGrid/ThematicCardsValues.js
@@ -8,48 +8,44 @@ const ThematicCardsValues = () => {
   const { translations } = useLanguage();
   return (
     <div
-      className="flex flex-col justify-center items-center -mt-16 mb-4 lg:mb-8 lg:mx-1"
+      className="flex flex-col justify-center items-center mx-1 -mt-12 mb-4 lg:-mt-8 lg:mb-8 lg:mx-2"
       data-testid="thematicGrid"
     >
       <div
-        className="grid grid-cols-1 sm:grid-cols-2 md:gap-3 lg:grid-cols-1 gap-2"
+        className="flex flex-wrap justify-around w-full gap-x-4 gap-y-2 lg:gap-2"
         data-testid="thematicGrid"
       >
         <ThematicCard
           imageUrl="/images/thematic-cards/thematic-territoriality.png"
-          imgPos="left"
+          cardVariant="variant1"
           smallCardSize="small"
           title={translations["thematic.h1"]}
           descriptionStart={translations["thematic.p1-start"]}
           descriptionEnd={translations["thematic.p1-end"]}
-          backgroundColor="#E8ECE9"
         />
         <ThematicCard
           imageUrl="/images/thematic-cards/thematic-craftsmanship.png"
-          imgPos="right"
+          cardVariant="variant2"
           smallCardSize="small2"
           title={translations["thematic.h2"]}
           descriptionStart={translations["thematic.p2-start"]}
           descriptionEnd={translations["thematic.p2-end"]}
-          backgroundColor="#B7C3BC"
         />
         <ThematicCard
           imageUrl="/images/thematic-cards/thematic-yeast.png"
-          imgPos="left"
+          cardVariant="variant1"
           smallCardSize="big"
           title={translations["thematic.h3"]}
           descriptionStart={translations["thematic.p3-start"]}
           descriptionEnd={translations["thematic.p3-end"]}
-          backgroundColor="#E8ECE9"
         />
         <ThematicCard
           imageUrl="/images/thematic-cards/thematic-minimal.png"
-          imgPos="right"
+          cardVariant="variant2"
           smallCardSize="medium"
           title={translations["thematic.h4"]}
           descriptionStart={translations["thematic.p4-start"]}
           descriptionEnd={translations["thematic.p4-end"]}
-          backgroundColor="#B7C3BC"
         />
       </div>
     </div>

--- a/src/components/ContentGrid/ThematicCardsValues.js
+++ b/src/components/ContentGrid/ThematicCardsValues.js
@@ -26,7 +26,7 @@ const ThematicCardsValues = () => {
         <ThematicCard
           imageUrl="/images/thematic-cards/thematic-craftsmanship.png"
           cardVariant="variant2"
-          smallCardSize="small2"
+          smallCardSize="small"
           title={translations["thematic.h2"]}
           descriptionStart={translations["thematic.p2-start"]}
           descriptionEnd={translations["thematic.p2-end"]}


### PR DESCRIPTION
## More responsive, refactored ThematicCard-components
So I decided to to a combination of refactoring and enhancing responsivity in this PR. The refactor was achieved by replacing two props of the ThematicCard component (imgPos and backgroundColor) with one props called cardVariant which took both into consideration through logic within the component. This change was inspired by the changes Lenin made to the PhotoCard-component in order to ensure consistency across card-components. 

Regarding the responsivity, I enhanced it in several ways, but mainly by introducing the gap attribute in the outer div of the ThematicCard-component, which made the text behave more dynamically in response to the screen size (especially at larger screen sizes above lg). I also changed some of the margins of the h3 and p-elements in some small ways. I also made the cards behave more dynamically for tablet-sized screens by adding the flex justify-space-around which gives a nicer look in my opinion.

### Changes
- Less, more effective props for the card-component
- Adjusted different classes for the card-components to ensure more seemless responsivity
- Flex with space-around introduced at tablet-sized screens

![thematic-cards-different-screens](https://github.com/user-attachments/assets/3c6a13ac-bf84-4373-a74d-4cc40344b7bc)
