### PR TITLE
Responsiveness hero section fixed

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -9,7 +9,7 @@ import PhotoCardsTeamValues from "@/components/ContentGrid/PhotoCardsTeamValues"
 export default function Home() {
   return (
     <div className="flex w-[100%]" data-testid="home-container">
-      <main className="flex flex-col gap-4" data-testid="main-heading">
+      <main className="flex flex-col gap-4 w-full" data-testid="main-heading">
         <HeroSection />
         <PhotoCardsWineTasting />
         <Subscribe />

--- a/src/components/HeroSection/HeroSection.js
+++ b/src/components/HeroSection/HeroSection.js
@@ -13,11 +13,11 @@ const HeroSection = () => {
       data-testid="hero-section"
     >
       <div
-        className="relative flex flex-col p-4 md:p-8 pt-8 sm:pt-4 text-left justify-center md:w-1/2"
+        className="relative flex flex-col p-4 md:p-8 pt-8 sm:pt-4 text-left justify-center md:w-1/2 gap-8"
         data-testid="hero-text-container"
       >
-        <div className="absolute top-[0.7rem] right-[0.5rem] sm:top-[0rem] sm:right-[0rem] sm:relative flex justify-end sm:justify-start z-0 overflow-hidden">
-          <div className="relative w-[4.5rem] h-[6.75rem] sm:w-[10.35rem] sm:h-[6.93rem]">
+        <div className="absolute top-[0.7rem] right-[0.5rem] sm:right-auto sm:left-[2rem] sm:top-[2rem] flex justify-start z-0">
+          <div className="w-[4.5rem] h-[6.75rem] sm:w-[10.35rem] sm:h-[6.93rem]">
             <img
               src="/design-elements/Dotted Shape.svg"
               alt="Decorative shape"
@@ -33,20 +33,20 @@ const HeroSection = () => {
           </div>
         </div>
         <h1
-          className="text-displayMedium mt-8 md:text-displayLarge text-tertiary1-darker font-barlow z-10 w-[20.5rem] md:w-full xl:w-[40rem]"
+          className="text-displayMedium sm:bg-primary-light md:text-displayLarge text-tertiary1-darker font-barlow z-10 w-[20.5rem] md:w-full xl:w-[40rem]"
           id="title"
           data-testid="title"
         >
           {translations["hero.heading"]}
         </h1>
         <p
-          className="text-bodyLarge text-tertiary1-darker z-10 mt-8"
+          className="text-bodyLarge text-tertiary1-darker z-10"
           data-testid="description"
         >
           {translations["hero.paragraph"]}
         </p>
         <div className="flex flex-col w-full">
-          <div className="flex flex-col w-full gap-4 sm:flex-row z-10 mt-8">
+          <div className="flex flex-col w-full gap-4 sm:flex-row z-10 sm:bg-primary-light">
             <Button
               text={translations["hero.button-left"]}
               icon="/icons/cart.svg"
@@ -62,8 +62,8 @@ const HeroSection = () => {
               testId="secondary-button"
             />
           </div>
-          <div className="absolute bottom-[7.5rem] md:bottom-auto right-[0.5rem] sm:top-auto sm:right-auto sm:relative flex justify-end overflow-hidden">
-            <div className="relative w-[7.5rem] h-[4.5rem] sm:w-[13.75rem] sm:h-[8.68rem] mb-[1rem] sm:mb-[0rem] z-0">
+          <div className="absolute bottom-[8.75rem] right-[1rem] flex justify-end sm:right-[3rem] sm:bottom-[2rem]">
+            <div className="w-[7.5rem] h-[4.5rem] sm:w-[13.75rem] sm:h-[8.68rem] mb-[1rem] sm:mb-[0rem] z-0">
               <img
                 src="/design-elements/Dotted Shape.svg"
                 alt="Decorative shape"

--- a/src/components/HeroSection/HeroSection.js
+++ b/src/components/HeroSection/HeroSection.js
@@ -6,35 +6,42 @@ const HeroSection = () => {
   const { translations } = useLanguage();
   return (
     <section
-      className="sm:mt-6 relative flex justify-between flex-col h-[53.2rem] w-screen sm:h-[44rem] sm:flex-row  bg-primary-light "
+      className="mt-6 relative flex justify-between flex-col w-full md:h-[44rem] md:flex-row bg-primary-light"
       role="banner"
       aria-label="Hero Section"
       aria-labelledby="title"
       data-testid="hero-section"
     >
       <div
-        className="relative flex flex-col p-4 pt-8 sm:pt-4 gap-8 h-[31.6rem] justify-center sm:w-[44rem] sm:h-[44rem] sm:justify-center text-left sm:gap-8 m-0"
+        className="relative flex flex-col p-4 md:p-8 pt-8 sm:pt-4 gap-8 text-left sm:gap-8 justify-center md:w-1/2"
         data-testid="hero-text-container"
       >
-        <div className="absolute top-[0.7rem] right-[0.5rem] sm:top-[0rem] sm:right-[0rem] sm:relative flex justify-end sm:justify-start z-0 overflow-hidden">
-          <div className="relative w-[4.5rem] h-[6.75rem] sm:w-[10.35rem] sm:h-[6.93rem]">
-            <img
-              src="/design-elements/Dotted Shape.svg"
-              alt=""
-              className="absolute top-0 left:0 sm:top-auto sm:top-0 sm:right-0 w-[3rem] h-[3rem] sm:w-[4.6rem] sm:h-[4.6rem]"
-              data-testid="dotted-shape-1"
-            />
-            <img
-              src="/design-elements/Dotted Shape.svg"
-              alt=""
-              className="absolute bottom-0 right-0 sm:bottom-0 sm:left-0 w-[3rem] h-[3rem] sm:w-[4.6rem] sm:h-[4.6rem]"
-              data-testid="dotted-shape-2"
-            />
-          </div>
-        </div>
-
+        <img
+          src="/design-elements/Dotted Shape.svg"
+          alt="Decorative dotted shape"
+          className="absolute top-3 md:top-[73px] md:left-8 right-7 w-[3rem] h-[3rem] md:w-[4.8rem] md:h-[4.8rem]"
+          data-testid="dotted-shape-1"
+        />
+        <img
+          src="/design-elements/Dotted Shape.svg"
+          alt="Decorative dotted shape"
+          className="absolute top-[4.375rem] md:top-8 md:left-[133.4px] right-1.5 w-[3rem] h-[3rem] md:w-[4.8rem] md:h-[4.8rem]"
+          data-testid="dotted-shape-2"
+        />
+        <img
+          src="/design-elements/Dotted Shape.svg"
+          alt="Decorative dotted shape"
+          className="absolute top-[294px] md:right-8 md:top-[530px] right-4 w-[3rem] h-[3rem] md:w-[93px] md:h-[93px]"
+          data-testid="dotted-shape-3"
+        />
+        <img
+          src="/design-elements/Dotted Shape.svg"
+          alt="Decorative dotted shape"
+          className="absolute top-[318px] md:top-[579px] right-[82px] md:right-[169px] w-[3rem] h-[3rem] md:w-[93px] md:h-[93px]"
+          data-testid="dotted-shape-4"
+        />
         <h1
-          className="text-displayMedium sm:text-displayLarge text-tertiary1-normal font-barlow z-10"
+          className="text-displayMedium md:text-displayLarge text-tertiary1-darker font-barlow z-10 w-[20.5rem] xl:w-[40rem]"
           id="title"
           data-testid="title"
         >
@@ -55,7 +62,6 @@ const HeroSection = () => {
               ariaLabel="Visit our shop"
               testId="get-started-button"
             />
-
             <Button
               text={translations["hero.button-right"]}
               icon="/icons/speech-bubble-19.svg"
@@ -64,28 +70,12 @@ const HeroSection = () => {
               testId="secondary-button"
             />
           </div>
-          <div className="absolute top-[15.8rem] right-[0.5rem] sm:top-auto sm:right-auto sm:relative flex justify-end overflow-hidden">
-            <div className="relative w-[7.5rem] h-[4.5rem] sm:w-[13.75rem] sm:h-[8.68rem] mb-[1rem] sm:mb-[0rem] z-0">
-              <img
-                src="/design-elements/Dotted Shape.svg"
-                alt=""
-                className="absolute top-0 right-0 w-[3rem] h-[3rem] sm:w-[5.8rem] sm:h-[5.8rem]"
-                data-testid="dotted-shape-3"
-              />
-              <img
-                src="/design-elements/Dotted Shape.svg"
-                alt=""
-                className="absolute bottom-0 left-0 w-[3rem] h-[3rem] sm:w-[5.8rem] sm:h-[5.8rem]"
-                data-testid="dotted-shape-4"
-              />
-            </div>
-          </div>
         </div>
       </div>
 
-      <div className="relative justify-center h-[22rem] sm:w-[45rem] sm:h-[44rem]">
+      <div className="relative justify-center h-[22rem] md:h-[44rem] md:w-1/2 w-full">
         <video
-          className="inset-0 h-[22rem] rounded-t-[6.8rem] sm:w-[45rem] sm:h-[44rem] sm:rounded-tl-[6.8rem] sm:rounded-tr-none object-cover"
+          className="inset-0 h-[22rem] rounded-t-[6.8rem] md:h-[44rem] md:rounded-tl-[6.8rem] rounded-b-[0.5rem] md:rounded-b-none md:rounded-tr-none object-cover"
           autoPlay
           loop
           muted

--- a/src/components/HeroSection/HeroSection.js
+++ b/src/components/HeroSection/HeroSection.js
@@ -13,48 +13,40 @@ const HeroSection = () => {
       data-testid="hero-section"
     >
       <div
-        className="relative flex flex-col p-4 md:p-8 pt-8 sm:pt-4 gap-8 text-left sm:gap-8 justify-center md:w-1/2"
+        className="relative flex flex-col p-4 md:p-8 pt-8 sm:pt-4 text-left justify-center md:w-1/2"
         data-testid="hero-text-container"
       >
-        <img
-          src="/design-elements/Dotted Shape.svg"
-          alt="Decorative dotted shape"
-          className="absolute top-3 md:top-[73px] md:left-8 right-7 w-[3rem] h-[3rem] md:w-[4.8rem] md:h-[4.8rem]"
-          data-testid="dotted-shape-1"
-        />
-        <img
-          src="/design-elements/Dotted Shape.svg"
-          alt="Decorative dotted shape"
-          className="absolute top-[4.375rem] md:top-8 md:left-[133.4px] right-1.5 w-[3rem] h-[3rem] md:w-[4.8rem] md:h-[4.8rem]"
-          data-testid="dotted-shape-2"
-        />
-        <img
-          src="/design-elements/Dotted Shape.svg"
-          alt="Decorative dotted shape"
-          className="absolute top-[294px] md:right-8 md:top-[530px] right-4 w-[3rem] h-[3rem] md:w-[93px] md:h-[93px]"
-          data-testid="dotted-shape-3"
-        />
-        <img
-          src="/design-elements/Dotted Shape.svg"
-          alt="Decorative dotted shape"
-          className="absolute top-[318px] md:top-[579px] right-[82px] md:right-[169px] w-[3rem] h-[3rem] md:w-[93px] md:h-[93px]"
-          data-testid="dotted-shape-4"
-        />
+        <div className="absolute top-[0.7rem] right-[0.5rem] sm:top-[0rem] sm:right-[0rem] sm:relative flex justify-end sm:justify-start z-0 overflow-hidden">
+          <div className="relative w-[4.5rem] h-[6.75rem] sm:w-[10.35rem] sm:h-[6.93rem]">
+            <img
+              src="/design-elements/Dotted Shape.svg"
+              alt="Decorative shape"
+              className="absolute top-0 left:0 sm:top-auto sm:top-0 sm:right-0 w-[3rem] h-[3rem] sm:w-[4.6rem] sm:h-[4.6rem]"
+              data-testid="dotted-shape-1"
+            />
+            <img
+              src="/design-elements/Dotted Shape.svg"
+              alt="Decorative shape"
+              className="absolute bottom-0 right-0 sm:bottom-0 sm:left-0 w-[3rem] h-[3rem] sm:w-[4.6rem] sm:h-[4.6rem]"
+              data-testid="dotted-shape-2"
+            />
+          </div>
+        </div>
         <h1
-          className="text-displayMedium md:text-displayLarge text-tertiary1-darker font-barlow z-10 w-[20.5rem] xl:w-[40rem]"
+          className="text-displayMedium mt-8 md:text-displayLarge text-tertiary1-darker font-barlow z-10 w-[20.5rem] md:w-full xl:w-[40rem]"
           id="title"
           data-testid="title"
         >
           {translations["hero.heading"]}
         </h1>
         <p
-          className="text-bodyLarge text-tertiary1-darker z-10"
+          className="text-bodyLarge text-tertiary1-darker z-10 mt-8"
           data-testid="description"
         >
           {translations["hero.paragraph"]}
         </p>
         <div className="flex flex-col w-full">
-          <div className="flex flex-col w-full gap-4 sm:flex-row z-10">
+          <div className="flex flex-col w-full gap-4 sm:flex-row z-10 mt-8">
             <Button
               text={translations["hero.button-left"]}
               icon="/icons/cart.svg"
@@ -70,12 +62,28 @@ const HeroSection = () => {
               testId="secondary-button"
             />
           </div>
+          <div className="absolute bottom-[7.5rem] md:bottom-auto right-[0.5rem] sm:top-auto sm:right-auto sm:relative flex justify-end overflow-hidden">
+            <div className="relative w-[7.5rem] h-[4.5rem] sm:w-[13.75rem] sm:h-[8.68rem] mb-[1rem] sm:mb-[0rem] z-0">
+              <img
+                src="/design-elements/Dotted Shape.svg"
+                alt="Decorative shape"
+                className="absolute top-0 right-0 w-[3rem] h-[3rem] sm:w-[5.8rem] sm:h-[5.8rem]"
+                data-testid="dotted-shape-3"
+              />
+              <img
+                src="/design-elements/Dotted Shape.svg"
+                alt="Decorative shape"
+                className="absolute bottom-0 left-0 w-[3rem] h-[3rem] sm:w-[5.8rem] sm:h-[5.8rem]"
+                data-testid="dotted-shape-4"
+              />
+            </div>
+          </div>
         </div>
       </div>
 
       <div className="relative justify-center h-[22rem] md:h-[44rem] md:w-1/2 w-full">
         <video
-          className="inset-0 h-[22rem] rounded-t-[6.8rem] md:h-[44rem] md:rounded-tl-[6.8rem] rounded-b-[0.5rem] md:rounded-b-none md:rounded-tr-none object-cover"
+          className="inset-0 h-[22rem] rounded-t-[6.8rem] md:h-[44rem] md:rounded-tl-[6.8rem] rounded-b-[0.5rem] md:rounded-b-none md:rounded-tr-none object-cover w-full"
           autoPlay
           loop
           muted

--- a/src/components/HeroSection/HeroSection.js
+++ b/src/components/HeroSection/HeroSection.js
@@ -20,13 +20,13 @@ const HeroSection = () => {
           <div className="w-[4.5rem] h-[6.75rem] sm:w-[10.35rem] sm:h-[6.93rem]">
             <img
               src="/design-elements/Dotted Shape.svg"
-              alt="Decorative shape"
+              alt=""
               className="absolute top-0 left:0 sm:top-auto sm:top-0 sm:right-0 w-[3rem] h-[3rem] sm:w-[4.6rem] sm:h-[4.6rem]"
               data-testid="dotted-shape-1"
             />
             <img
               src="/design-elements/Dotted Shape.svg"
-              alt="Decorative shape"
+              alt=""
               className="absolute bottom-0 right-0 sm:bottom-0 sm:left-0 w-[3rem] h-[3rem] sm:w-[4.6rem] sm:h-[4.6rem]"
               data-testid="dotted-shape-2"
             />
@@ -66,13 +66,13 @@ const HeroSection = () => {
             <div className="w-[7.5rem] h-[4.5rem] sm:w-[13.75rem] sm:h-[8.68rem] mb-[1rem] sm:mb-[0rem] z-0">
               <img
                 src="/design-elements/Dotted Shape.svg"
-                alt="Decorative shape"
+                alt=""
                 className="absolute top-0 right-0 w-[3rem] h-[3rem] sm:w-[5.8rem] sm:h-[5.8rem]"
                 data-testid="dotted-shape-3"
               />
               <img
                 src="/design-elements/Dotted Shape.svg"
-                alt="Decorative shape"
+                alt=""
                 className="absolute bottom-0 left-0 w-[3rem] h-[3rem] sm:w-[5.8rem] sm:h-[5.8rem]"
                 data-testid="dotted-shape-4"
               />


### PR DESCRIPTION
Refactored the decorative images, so there is less code now and it is more clean. Also fixed the positioning of the decorative images so they align with the design. Furthermore fixed the width of the video as it takes up 50% of the screen on the desktop/ipad/larger devices. Fixed the colors of the heading co it is according to design.
Fixed the height of the component on small screen so it is responsive and there is not extra empty space on smaller phones. Fixed the styling of the video as it was missing the rounded corners on the bottom on the small screens.
Kept the extra white space on top of the component on both desktop and mobile as Davide wanted.

Used mobile first approach when applying styling - default style is for the smallest screen, all bigger screen sizes use corresponding tailwind css breakpoints md:,lg:,xl.

Testing file was not updated as the elements in the test were not changed.

Design on the desktop after fixes: 
![image](https://github.com/user-attachments/assets/003a8621-309b-4577-a2d3-077350eeeee6)

Design on iPad:
![image](https://github.com/user-attachments/assets/7083bf11-04cd-46ac-b973-7b458991829c)

Design on phone:
![image](https://github.com/user-attachments/assets/be066dda-1c84-4ba3-a74c-646221505f6a)
![image](https://github.com/user-attachments/assets/24de6812-944b-4e39-a4fc-2bf66b12483e)


