### PR TITLE
Photo cards wine tasting responsiveness fixes

### DIFF
--- a/src/__tests__/componentsTest/PhotoCardsTeamValues.test.js
+++ b/src/__tests__/componentsTest/PhotoCardsTeamValues.test.js
@@ -61,7 +61,7 @@ describe("PhotoCardsTeamValues Component", () => {
 
     // Check grid layout for medium screens (above sm)
     const grid = screen.getByTestId("photo-cards-team-values");
-    expect(grid).toHaveClass("sm:grid-cols-2");
+    expect(grid).toHaveClass("xl:grid-cols-2");
   });
 
   it("checks if the background and text color classes are correct in variant 1", () => {

--- a/src/__tests__/componentsTest/PhotoCardsWineTasting.test.js
+++ b/src/__tests__/componentsTest/PhotoCardsWineTasting.test.js
@@ -61,7 +61,7 @@ describe("PhotoCardsWineTasting Component", () => {
 
     // Check grid layout for medium screens (above sm)
     const grid = screen.getByTestId("photo-cards-wine-tasting");
-    expect(grid).toHaveClass("sm:grid-cols-2");
+    expect(grid).toHaveClass("xl:grid-cols-2");
   });
 
   it("checks if the background and text color classes are correct in variant 1", () => {

--- a/src/components/Card/PhotoCard.js
+++ b/src/components/Card/PhotoCard.js
@@ -23,31 +23,31 @@ const PhotoCard = ({
 
   return (
     <article
-      className={`relative flex flex-col rounded-[2rem] w-full h-[37.5rem] sm:h-[33.5rem] sm:flex-row gap-8 items-center ${variantClass}`}
+      className={`relative flex flex-col rounded-[2rem] w-full sm:h-[25rem] xl:h-[33.5rem] sm:flex-row items-center ${variantClass}`}
       data-testid="photo-card"
       aria-labelledby="photo-card-title"
       aria-describedby="photo-card-description"
     >
       <figure
-        className={`overflow-hidden rounded-tl-[2rem] rounded-tr-[2rem] sm:rounded-tr-none sm:rounded-tl-[2rem] sm:rounded-bl-[2rem]`}
+        className={`overflow-hidden rounded-tl-[2rem] w-full h-[12.375rem] sm:min-w-[40%] sm:w-2/5 xl:min-w-[25.75rem] xl:w-[25.75rem] sm:h-[25rem] xl:h-[33.5rem] rounded-tr-[2rem] sm:rounded-tr-none sm:rounded-tl-[2rem] sm:rounded-bl-[2rem]`}
         data-testid="photo-card-image"
         aria-labelledby="photo-card-title"
       >
         <img
           src={imageUrl}
           alt={title}
-          className="object-cover w-[21.5rem] h-[12.375rem] sm:w-[25.75rem] sm:h-[33.5rem]"
+          className="object-cover h-full w-full"
           data-testid="card-image"
           aria-label={`Image representing ${title}`}
         />
       </figure>
 
       <div
-        className="flex flex-col w-[18.5rem] sm:h-[33.5rem] gap-8 sm:p-6 sm:py-8 justify-center"
+        className="flex flex-col px-6 gap-8 pb-10 justify-center sm:items-start md:pb-0 md:px-4"
         data-testid="photo-card-content"
       >
         <h3
-          className="text-displaySmall font-barlow font-medium "
+          className="text-displaySmall font-barlow font-medium mt-4 sm:mt-0"
           id="photo-card-title"
           data-testid="photo-card-title"
           aria-label={`Card title: ${title}`}

--- a/src/components/Card/PhotoCardSmaller.js
+++ b/src/components/Card/PhotoCardSmaller.js
@@ -23,31 +23,31 @@ const PhotoCardSmaller = ({
 
   return (
     <div
-      className={`relative flex flex-col rounded-[2rem] w-full h-[32.125rem] sm:h-[28.5rem] sm:flex-row items-center ${variantClass}`}
+      className={`relative flex flex-col rounded-[2rem] w-full xl:h-[28.5rem] sm:h-[25rem] sm:flex-row items-center ${variantClass}`}
       data-testid="photo-card-smaller"
       aria-labelledby="photo-card-title"
       aria-describedby="photo-card-description"
     >
       <figure
-        className={`overflow-hidden rounded-tl-[2rem] rounded-tr-[2rem] sm:rounded-tr-none sm:rounded-tl-[2rem] sm:rounded-bl-[2rem]`}
+        className={`overflow-hidden rounded-tl-[2rem] rounded-tr-[2rem] sm:rounded-tr-none sm:rounded-tl-[2rem] sm:rounded-bl-[2rem] w-full sm:min-w-[40%] sm:w-2/5 xl:min-w-[25.75rem] xl:w-[25.75rem] h-[12.375rem] sm:h-[25rem] w-full xl:h-[28.5rem]`}
         data-testid="photo-card-image"
         aria-labelledby="photo-card-title"
       >
         <img
           src={imageUrl}
           alt={title}
-          className="object-cover w-[21.25rem] h-[12.375rem] sm:w-[25.75rem] sm:h-[28.5rem]"
+          className="object-cover w-full h-full"
           data-testid="card-image"
           aria-label={`Image representing ${title}`}
         />
       </figure>
 
       <div
-        className="flex flex-col w-[18.5rem] sm:h-[28.5rem] gap-8 sm:p-6 sm:py-8 justify-center h-[19.75rem]"
+        className="flex flex-col gap-8 px-6 pb-10 justify-center sm:items-start md:pb-0 md:px-4"
         data-testid="photo-card-content"
       >
         <h3
-          className="text-displaySmall font-barlow font-medium"
+          className="text-displaySmall font-barlow font-medium mt-4 sm:mt-0"
           id="photo-card-title"
           data-testid="photo-card-title"
           aria-label={`Card title: ${title}`}

--- a/src/components/ContentGrid/PhotoCardsTeamValues.js
+++ b/src/components/ContentGrid/PhotoCardsTeamValues.js
@@ -8,7 +8,7 @@ const PhotoCardsTeamValues = () => {
   const { translations } = useLanguage();
   return (
     <div
-      className="grid grid-col-1 sm:grid-cols-2 w-full justify-center items-center gap-4 px-2 sm:p-2 place-items-center"
+      className="grid grid-col-1 xl:grid-cols-2 w-full justify-center items-center gap-4 px-2 lg:p-2 place-items-center mb-4"
       data-testid="photo-cards-team-values"
     >
       <PhotoCardSmaller

--- a/src/components/ContentGrid/PhotoCardsWineTasting.js
+++ b/src/components/ContentGrid/PhotoCardsWineTasting.js
@@ -8,7 +8,7 @@ const PhotoCardsWineTasting = () => {
   const { translations } = useLanguage();
   return (
     <div
-      className="grid grid-col-1 sm:grid-cols-2 w-full justify-center items-center gap-2 px-2 sm:p-2 place-items-center"
+      className="grid grid-col-1 xl:grid-cols-2 w-full justify-center items-center gap-2 px-2 lg:p-2 place-items-center"
       data-testid="photo-cards-wine-tasting"
     >
       <PhotoCard


### PR DESCRIPTION
Fixed the responsiveness for both Photo Cards WineTasting and Photo Cards TeamValues. 
Adjusted how it looks on tablets and small large screens as with current solution the text was getting too squeezed. Set the width of the image so it would take up 45% of the component. As we currently don't have design for this sized screens I went with what I thought looked good. This way both the image and text are visible and not squeezed.
Removed set widths and heights for components on some screens to assure it is responsive for all devices and used paddings and margins instead.

**Photo Card Wine Tasting Large screen:**
![image](https://github.com/user-attachments/assets/96c0088a-dade-4b6f-90e8-95769d5f91a5)

**Photo Card Wine Large Tablet screen:**
![image](https://github.com/user-attachments/assets/cc27424a-ec60-4707-8595-f9e18bd5445d)

**Photo Card Wine small Tablet screen:**
![image](https://github.com/user-attachments/assets/8c19caca-3337-428b-b651-4d3d6db5e2b5)

**Photo Card Wine phone screen:**

![image](https://github.com/user-attachments/assets/e0000a08-5961-4ccc-8c40-ef68a5e9058e)
![image](https://github.com/user-attachments/assets/57838316-d3a7-4b49-adaf-4e4543f5aeb0)


**Photo Card Team Values Large screen:**
![image](https://github.com/user-attachments/assets/58cf78e0-c59e-4bb8-9314-74a4720441e6)

**Photo Card Team Values Large Tablet screen:**
![image](https://github.com/user-attachments/assets/ad61b54d-c211-4090-9119-0bde20e7d2b1)


**Photo Card Team Values small Tablet screen:**
![image](https://github.com/user-attachments/assets/3047c7d4-c240-43ed-8fe8-799097fe873f)

**Photo Card Team Values phone screen:**
![image](https://github.com/user-attachments/assets/27ef5789-0d12-46d6-9f47-a7bd5ffe0705)
![image](https://github.com/user-attachments/assets/eb9e8827-11fc-4fac-9bc5-8844c32bb1d4)


