### PR TITLE
Switch video hosting to YouTube due to Cloudinary 5GB traffic limit, continue using Cloudinary for e-commerce images

### DIFF
--- a/src/components/HeroSection/HeroSection.js
+++ b/src/components/HeroSection/HeroSection.js
@@ -93,7 +93,7 @@ const HeroSection = () => {
           data-testid="hero-video"
         >
           <source
-            src="https://res.cloudinary.com/dmjo57kua/video/upload/v1735578255/Sequence_01_dnkdcc.mp4"
+            src="https://res.cloudinary.com/dxnptdhrp/video/upload/v1735508300/sgx733bdfjq7rvcv9x7p.mp4"
             type="video/mp4"
           />
           Your browser does not support the video tag.


### PR DESCRIPTION

---

### **Description:**

Cloudinary's free plan has a 5GB traffic limit. Since the video file is 50MB and we are using it frequently, we reached this limit. As a temporary solution, I switched the video hosting to YouTube by using a YouTube link instead of directly hosting the video on Cloudinary.

However, Cloudinary remains a great option for storing and optimizing e-commerce images, and I recommend continuing to use it for this purpose.

### **Changes made:**

- Replaced video file hosted on Cloudinary with a YouTube link to avoid exceeding the traffic limit.
- No changes made to the image storage on Cloudinary; it's still being used for e-commerce images.

---
