### PR TITLE
Minimally adjust ContactUs component to use useFetch for /web/contact request

### DIFF
--- a/src/__tests__/componentsTest/ContactUs.test.js
+++ b/src/__tests__/componentsTest/ContactUs.test.js
@@ -31,12 +31,14 @@ describe("ContactUs Component", () => {
     renderWithProvider("en");
 
     const locationTitle = screen.getByText("Our Location");
-    const locationDescription = screen.getByText("Christianshavn, Copenhagen");
+    const locationDescription = screen.getByText(
+      "Christianshavns Voldgade 54, 1424 København",
+    );
     expect(locationTitle).toBeInTheDocument();
     expect(locationDescription).toBeInTheDocument();
 
     const phoneTitle = screen.getByText("Phone Number");
-    const phoneDescription = screen.getByText("(+45) 12 34 56 78");
+    const phoneDescription = screen.getByText("(+45) 31 62 06 93");
     expect(phoneTitle).toBeInTheDocument();
     expect(phoneDescription).toBeInTheDocument();
 

--- a/src/__tests__/utilsTest/validators.test.js
+++ b/src/__tests__/utilsTest/validators.test.js
@@ -1,0 +1,17 @@
+import { isValidEmail } from "@/utils/validators";
+
+describe("Email Validation", () => {
+  test("valid emails", () => {
+    expect(isValidEmail("test@example.com")).toBe(true);
+    expect(isValidEmail("user.name@domain.co")).toBe(true);
+    expect(isValidEmail("hello123@sub.domain.org")).toBe(true);
+  });
+
+  test("invalid emails", () => {
+    expect(isValidEmail("invalid-email")).toBe(false);
+    expect(isValidEmail("user@domain")).toBe(false);
+    expect(isValidEmail("user@.com")).toBe(false);
+    expect(isValidEmail("@domain.com")).toBe(false);
+    expect(isValidEmail("user@domain,com")).toBe(false);
+  });
+});

--- a/src/components/ContactUs/ContactUs.js
+++ b/src/components/ContactUs/ContactUs.js
@@ -1,8 +1,10 @@
 import React from "react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Button from "../Button/Button";
 import useFetch from "@/hooks/api/useFetch";
 import { useLanguage } from "@/app/context/LanguageContext";
+import { isValidEmail } from "@/utils/validators";
+import { logInfo } from "@/utils/logging";
 
 const ContactUs = () => {
   const { translations } = useLanguage();
@@ -14,27 +16,40 @@ const ContactUs = () => {
     message: "",
   });
 
-  const { performFetch, isLoading, error, data } = useFetch("/contact", "POST");
+  const { performFetch, isLoading, error, data } = useFetch(
+    "/web/contact",
+    "POST",
+  );
 
   const handleChange = (e) => {
     setFormData({ ...formData, [e.target.name]: e.target.value });
   };
 
   const handleSubmit = async (e) => {
+    logInfo("error");
     e.preventDefault();
+
+    if (!isValidEmail(formData.email)) {
+      alert("The email format is invalid. Please enter a valid email address.");
+      return;
+    }
 
     await performFetch(formData);
 
+    logInfo(`request data: ${JSON.stringify(formData)}`);
+
     if (data?.success) {
       alert("Message sent successfully");
-      setFormData({ name: "", email: "", phone: "", message: "" }); // Reset form
+      setFormData({ name: "", email: "", phone: "", message: "" });
     }
   };
 
-  <meta
-    name="description"
-    content="Get in touch with us. We are located in Copenhagen. Contact us for inquiries about our products or services."
-  ></meta>;
+  // Error handling
+  useEffect(() => {
+    if (error) {
+      alert("Message could not be sent. Please try again later.");
+    }
+  }, [error]);
 
   const infoItems = [
     {
@@ -112,6 +127,7 @@ const ContactUs = () => {
               <form
                 action="#"
                 method="POST"
+                onSubmit={handleSubmit}
                 className="space-y-4 z-50"
                 aria-labelledby="contact-us-form"
               >
@@ -122,6 +138,8 @@ const ContactUs = () => {
                   type="text"
                   name="name"
                   placeholder={translations["contact.label-name"]}
+                  value={formData.name}
+                  onChange={handleChange}
                   className="w-full border border-[#DFE4EA] rounded-md p-3 focus:outline-none focus:border-[#22AD5C]"
                 />
                 <label htmlFor="email" className="sr-only">
@@ -131,6 +149,8 @@ const ContactUs = () => {
                   type="email"
                   name="email"
                   placeholder={translations["contact.label-mail"]}
+                  value={formData.email}
+                  onChange={handleChange}
                   className="w-full border border-[#DFE4EA] rounded-md p-3 focus:outline-none focus:border-[#22AD5C]"
                 />
                 <label htmlFor="phone" className="sr-only">
@@ -140,6 +160,8 @@ const ContactUs = () => {
                   type="tel"
                   name="phone"
                   placeholder={translations["contact.label-phone"]}
+                  value={formData.phone}
+                  onChange={handleChange}
                   className="w-full border border-[#DFE4EA] rounded-md p-3 focus:outline-none focus:border-[#22AD5C]"
                 />
                 <label htmlFor="message" className="sr-only">
@@ -149,14 +171,24 @@ const ContactUs = () => {
                   placeholder={translations["contact.label-message"]}
                   name="message"
                   className="w-full border border-[#DFE4EA] rounded-md p-3 focus:outline-none focus:border-[#22AD5C]"
+                  value={formData.message}
+                  onChange={handleChange}
                   rows="4"
                 ></textarea>
-                <Button
-                  text={translations["contact.button-submit"]}
-                  variant="greenSubmit"
-                  ariaLabel="Send Message"
-                  testId="secondary-normal-send-message-button"
-                />
+                {isLoading ? (
+                  <div className="flex justify-center">
+                    <div className="spinner border-4 border-t-4 border-gray-300 border-t-[#22AD5C] rounded-full w-10 h-10 animate-spin"></div>
+                  </div>
+                ) : (
+                  <Button
+                    type="submit"
+                    onClick={handleSubmit}
+                    text={translations["contact.button-submit"]}
+                    variant="greenSubmit"
+                    ariaLabel="Send Message"
+                    testId="secondary-normal-send-message-button"
+                  />
+                )}
               </form>
             </section>
             <img

--- a/src/components/ContactUs/ContactUs.js
+++ b/src/components/ContactUs/ContactUs.js
@@ -26,7 +26,6 @@ const ContactUs = () => {
   };
 
   const handleSubmit = async (e) => {
-    logInfo("error");
     e.preventDefault();
 
     if (!isValidEmail(formData.email)) {
@@ -36,7 +35,7 @@ const ContactUs = () => {
 
     await performFetch(formData);
 
-    logInfo(`request data: ${JSON.stringify(formData)}`);
+    logInfo(`formData: ${JSON.stringify(formData)}`);
 
     if (data?.success) {
       alert("Message sent successfully");

--- a/src/components/ContactUs/ContactUs.js
+++ b/src/components/ContactUs/ContactUs.js
@@ -1,9 +1,36 @@
 import React from "react";
+import { useState } from "react";
 import Button from "../Button/Button";
+import useFetch from "@/hooks/api/useFetch";
 import { useLanguage } from "@/app/context/LanguageContext";
 
 const ContactUs = () => {
   const { translations } = useLanguage();
+
+  const [formData, setFormData] = useState({
+    name: "",
+    email: "",
+    phone: "",
+    message: "",
+  });
+
+  const { performFetch, isLoading, error, data } = useFetch("/contact", "POST");
+
+  const handleChange = (e) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+
+    await performFetch(formData);
+
+    if (data?.success) {
+      alert("Mensaje enviado correctamente");
+      setFormData({ name: "", email: "", phone: "", message: "" }); // Reset form
+    }
+  };
+
   <meta
     name="description"
     content="Get in touch with us. We are located in Copenhagen. Contact us for inquiries about our products or services."
@@ -13,12 +40,12 @@ const ContactUs = () => {
     {
       icon: "/icons/location-red.svg",
       title: translations["contact.subheading1"],
-      description: "Christianshavn, Copenhagen",
+      description: "Christianshavns Voldgade 54, 1424 København",
     },
     {
       icon: "/icons/phone-map-red.svg",
       title: translations["contact.subheading2"],
-      description: "(+45) 12 34 56 78",
+      description: "(+45) 31 62 06 93",
     },
     {
       icon: "/icons/email-red.svg",

--- a/src/components/ContactUs/ContactUs.js
+++ b/src/components/ContactUs/ContactUs.js
@@ -26,7 +26,7 @@ const ContactUs = () => {
     await performFetch(formData);
 
     if (data?.success) {
-      alert("Mensaje enviado correctamente");
+      alert("Message sent successfully");
       setFormData({ name: "", email: "", phone: "", message: "" }); // Reset form
     }
   };

--- a/src/components/Subscribe/Subscribe.js
+++ b/src/components/Subscribe/Subscribe.js
@@ -106,7 +106,7 @@ const Subscribe = () => {
             </div>
             {errors && (
               <div
-                className="sm:mx-8 mx-4 pb-2 text-red-500"
+                className="sm:mx-8 mx-4 pb-2 text-red-500 text-center"
                 aria-live="assertive"
                 data-testid="error-message"
               >
@@ -116,7 +116,7 @@ const Subscribe = () => {
 
             {successMessage && (
               <div
-                className="sm:mx-8 mx-4 pb-2 text-green-500"
+                className="sm:mx-8 mx-4 pb-2 text-green-500 text-center"
                 aria-live="assertive"
                 data-testid="success-message"
               >

--- a/src/config/environment.js
+++ b/src/config/environment.js
@@ -1,8 +1,8 @@
 import { API_URL_HEROKU } from "@env";
-// import { API_URL_LOCAL } from "@env";
+import { API_URL_LOCAL } from "@env";
 import { logInfo } from "@/utils/logging";
 
-export const baseApiUrl = API_URL_HEROKU;
-// export const baseApiUrl = API_URL_LOCAL;
+// export const baseApiUrl = API_URL_HEROKU;
+export const baseApiUrl = API_URL_LOCAL;
 
 logInfo(`Server url: ${baseApiUrl}`);

--- a/src/config/environment.js
+++ b/src/config/environment.js
@@ -1,8 +1,8 @@
 import { API_URL_HEROKU } from "@env";
-import { API_URL_LOCAL } from "@env";
+// import { API_URL_LOCAL } from "@env";
 import { logInfo } from "@/utils/logging";
 
-// export const baseApiUrl = API_URL_HEROKU;
-export const baseApiUrl = API_URL_LOCAL;
+export const baseApiUrl = API_URL_HEROKU;
+// export const baseApiUrl = API_URL_LOCAL;
 
 logInfo(`Server url: ${baseApiUrl}`);

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -1,0 +1,4 @@
+export const isValidEmail = (email) => {
+  const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+  return emailRegex.test(email);
+};


### PR DESCRIPTION
**Description:**  
In this pull request, I made minimal adjustments to the ContactUs component to utilize the useFetch hook for making a request to `/web/contact`. This route does not exist yet—I will work on it in a separate backend pull request. Additionally, I added images to demonstrate that the following fields are being sent: name, email, phone number, and message.

I also created a function to validate the email format. For now, I’m handling error and success messages using alert dialogs, as there is currently no space in the design to integrate them properly.

![Captura de Pantalla 2025-02-21 a la(s) 19 41 10](https://github.com/user-attachments/assets/ced8f27b-123a-4d21-bd8b-e54cfd43c460)
![Captura de Pantalla 2025-02-21 a la(s) 19 40 34](https://github.com/user-attachments/assets/039ddbb4-4efb-4509-b90f-11d19bd1cb18)


Note: There is an ESLint warning in useFetch regarding the `body` parameter, even though it appears to be used. I am leaving it as-is for now to keep progress moving forward.