### PR TITLE
fix(hero-section): ensure homepage video auto-plays inline on mobile

### DIFF
--- a/src/components/HeroSection/HeroSection.js
+++ b/src/components/HeroSection/HeroSection.js
@@ -102,6 +102,8 @@ const HeroSection = () => {
           autoPlay
           loop
           muted
+          playsInline
+          webkit-playsinline="true"
           role="region"
           aria-label="Background video for Hero Section"
           aria-hidden="true"


### PR DESCRIPTION
## Description

This PR fixes the homepage video so that it auto-plays inline on mobile devices
instead of unexpectedly going full-screen.

## What's Included

- Added `playsInline` and `webkit-playsinline="true"` to the video element
- Kept `autoPlay`, `muted`, and `loop` to maintain continuous, silent playback
- Ensured the video no longer forces full-screen on iOS Safari

## Additional Notes

- iOS Safari requires muted videos for auto-play
- `webkit-playsinline` is needed for older iOS versions

## Related Issue

Closes #237 
