### PR TITLE
Herosection video fallback

### DIFF
--- a/src/__tests__/componentsTest/HeroSection.test.js
+++ b/src/__tests__/componentsTest/HeroSection.test.js
@@ -64,26 +64,26 @@ describe("HeroSection Component", () => {
 
     const secondaryButton = screen.getByTestId("secondary-button");
     expect(secondaryButton).toBeInTheDocument();
-    it("should render the video if hasCredits is true", () => {
-      render(
-        <MockLanguageProvider>
-          <HeroSection hasCredits={true} />
-        </MockLanguageProvider>,
-      );
+  });
+  it("should render the video if hasCredits is true", () => {
+    render(
+      <MockLanguageProvider>
+        <HeroSection hasCredits={true} />
+      </MockLanguageProvider>,
+    );
 
-      const video = screen.getByTestId("hero-video");
-      expect(video).toBeInTheDocument();
-    });
+    const video = screen.getByTestId("hero-video");
+    expect(video).toBeInTheDocument();
+  });
 
-    it("should render the fallback image if hasCredits is false", () => {
-      render(
-        <MockLanguageProvider>
-          <HeroSection hasCredits={false} />
-        </MockLanguageProvider>,
-      );
+  it("should render the fallback image if hasCredits is false", () => {
+    render(
+      <MockLanguageProvider>
+        <HeroSection hasCredits={false} />
+      </MockLanguageProvider>,
+    );
 
-      const fallbackImage = screen.getByTestId("fallback-image");
-      expect(fallbackImage).toBeInTheDocument();
-    });
+    const fallbackImage = screen.getByTestId("fallback-image");
+    expect(fallbackImage).toBeInTheDocument();
   });
 });

--- a/src/__tests__/componentsTest/HeroSection.test.js
+++ b/src/__tests__/componentsTest/HeroSection.test.js
@@ -45,10 +45,6 @@ describe("HeroSection Component", () => {
       "Discover unique wine stories told by your sommelier while your private chef customizes the menu.",
     );
 
-    // Check that the video is present
-    const video = screen.getByTestId("hero-video");
-    expect(video).toBeInTheDocument();
-
     // Check that the dotted shapes images are present
     const dottedShape1 = screen.getByTestId("dotted-shape-1");
     expect(dottedShape1).toBeInTheDocument();
@@ -68,9 +64,26 @@ describe("HeroSection Component", () => {
 
     const secondaryButton = screen.getByTestId("secondary-button");
     expect(secondaryButton).toBeInTheDocument();
+    it("should render the video if hasCredits is true", () => {
+      render(
+        <MockLanguageProvider>
+          <HeroSection hasCredits={true} />
+        </MockLanguageProvider>,
+      );
 
-    // Check the video presence
-    const heroVideo = screen.getByTestId("hero-video");
-    expect(heroVideo).toBeInTheDocument();
+      const video = screen.getByTestId("hero-video");
+      expect(video).toBeInTheDocument();
+    });
+
+    it("should render the fallback image if hasCredits is false", () => {
+      render(
+        <MockLanguageProvider>
+          <HeroSection hasCredits={false} />
+        </MockLanguageProvider>,
+      );
+
+      const fallbackImage = screen.getByTestId("fallback-image");
+      expect(fallbackImage).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/HeroSection/HeroSection.js
+++ b/src/components/HeroSection/HeroSection.js
@@ -4,6 +4,7 @@ import ComingSoonModal from "../Modal/ComingSoonModal";
 import { useLanguage } from "@/app/context/LanguageContext";
 
 const HeroSection = () => {
+  const hasCredits = false;
   const { translations } = useLanguage();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -97,24 +98,31 @@ const HeroSection = () => {
       </div>
 
       <div className="relative justify-center h-[22rem] md:h-[44rem] md:w-1/2 w-full">
-        <video
-          className="inset-0 h-[22rem] rounded-t-[6.8rem] md:h-[44rem] md:rounded-tl-[6.8rem] rounded-b-[0.5rem] md:rounded-b-none md:rounded-tr-none object-cover w-full"
-          autoPlay
-          loop
-          muted
-          playsInline
-          webkit-playsinline="true"
-          role="region"
-          aria-label="Background video for Hero Section"
-          aria-hidden="true"
-          data-testid="hero-video"
-        >
-          <source
-            src="https://res.cloudinary.com/db3h63tns/video/upload/v1741092242/web-coorporate-hero-section_xi6jod.mp4"
-            type="video/mp4"
+        {hasCredits ? (
+          <video
+            className="inset-0 h-[22rem] rounded-t-[6.8rem] md:h-[44rem] md:rounded-tl-[6.8rem] rounded-b-[0.5rem] md:rounded-b-none md:rounded-tr-none object-cover w-full"
+            autoPlay
+            loop
+            muted
+            playsInline
+            webkit-playsinline="true"
+            role="region"
+            aria-label="Background video for Hero Section"
+            aria-hidden="true"
+            data-testid="hero-video"
+          >
+            <source
+              src="https://res.cloudinary.com/db3h63tns/video/upload/v1741092242/web-coorporate-hero-section_xi6jod.mp4"
+              type="video/mp4"
+            />
+            Your browser does not support the video tag.
+          </video>
+        ) : (
+          <img
+            src="/images/card-unsplash-wine-tasting.avif"
+            className="inset-0 h-[22rem] rounded-t-[6.8rem] md:h-[44rem] md:rounded-tl-[6.8rem] rounded-b-[0.5rem] md:rounded-b-none md:rounded-tr-none object-cover w-full"
           />
-          Your browser does not support the video tag.
-        </video>
+        )}
       </div>
     </section>
   );

--- a/src/components/HeroSection/HeroSection.js
+++ b/src/components/HeroSection/HeroSection.js
@@ -2,9 +2,9 @@ import React, { useState } from "react";
 import Button from "../Button/Button";
 import ComingSoonModal from "../Modal/ComingSoonModal";
 import { useLanguage } from "@/app/context/LanguageContext";
+import PropTypes from "prop-types";
 
-const HeroSection = () => {
-  const hasCredits = false;
+const HeroSection = ({ hasCredits = false }) => {
   const { translations } = useLanguage();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -121,11 +121,16 @@ const HeroSection = () => {
           <img
             src="/images/card-unsplash-wine-tasting.avif"
             className="inset-0 h-[22rem] rounded-t-[6.8rem] md:h-[44rem] md:rounded-tl-[6.8rem] rounded-b-[0.5rem] md:rounded-b-none md:rounded-tr-none object-cover w-full"
+            data-testid="fallback-image"
           />
         )}
       </div>
     </section>
   );
+};
+
+HeroSection.propTypes = {
+  hasCredits: PropTypes.bool,
 };
 
 export default HeroSection;


### PR DESCRIPTION
The Heroslider-video was not showing. When researching the problem I realized that it was the cloudinary credits that are used up for this month. To make a quick fix I made an image fallback for the video if there are no credits. Initially this solution is hardcoded with a prop-variable "hasCredits" that can be toggled on or off. If it is set to true the video will show, if not the image will show. This provides us with an easy way switch the video on or off. 

For future improvements, we might want to integrate with cloudinarys API to check if there still are credits for the month or not.