### PR TITLE
Fixing a typo in the e-mail of contact session

### DIFF
--- a/src/__tests__/componentsTest/ContactUs.test.js
+++ b/src/__tests__/componentsTest/ContactUs.test.js
@@ -43,7 +43,7 @@ describe("ContactUs Component", () => {
     expect(phoneDescription).toBeInTheDocument();
 
     const emailTitle = screen.getByText("Email Address");
-    const emailDescription = screen.getByText("info@donnvino.dk");
+    const emailDescription = screen.getByText("info@donnavino.dk");
     expect(emailTitle).toBeInTheDocument();
     expect(emailDescription).toBeInTheDocument();
   });

--- a/src/__tests__/componentsTest/MapSection.test.js
+++ b/src/__tests__/componentsTest/MapSection.test.js
@@ -44,7 +44,7 @@ describe("MapSection Component", () => {
     expect(phoneDescription).toBeInTheDocument();
 
     const emailTitle = screen.getByText("Email Address");
-    const emailDescription = screen.getByText("info@donnvino.dk");
+    const emailDescription = screen.getByText("info@donnavino.dk");
     expect(emailTitle).toBeInTheDocument();
     expect(emailDescription).toBeInTheDocument();
   });
@@ -88,7 +88,7 @@ describe("MapSection Component", () => {
     const phoneTitle = screen.getByText(/Phone Number/i);
     const phoneDescription = screen.getByText(/\+45 31 62 06 93/i);
     const emailTitle = screen.getByText(/Email Address/i);
-    const emailDescription = screen.getByText(/info@donnvino.dk/i);
+    const emailDescription = screen.getByText(/info@donnavino.dk/i);
 
     expect(locationTitle).toBeInTheDocument();
     expect(locationDescription).toBeInTheDocument();

--- a/src/components/ContactUs/ContactUs.js
+++ b/src/components/ContactUs/ContactUs.js
@@ -105,7 +105,7 @@ const ContactUs = () => {
     {
       icon: "/icons/email-red.svg",
       title: translations["contact.subheading3"],
-      description: "info@donnvino.dk",
+      description: "info@donnavino.dk",
     },
   ];
 

--- a/src/components/Map/MapSection.js
+++ b/src/components/Map/MapSection.js
@@ -33,7 +33,7 @@ const MapSection = () => {
     {
       icon: "/icons/email.svg",
       title: translations["contact.subheading3"],
-      description: <a href="mailto:info@donnvino.dk">info@donnvino.dk</a>,
+      description: <a href="mailto:info@donnavino.dk">info@donnavino.dk</a>,
     },
   ];
 


### PR DESCRIPTION
There was a typo. The e-mail said "info@donnvino.dk" instead of "info@donnavino.dk". It is now fixed.