### PR TITLE
Changing Default Language to Danish

### DIFF
--- a/src/__tests__/appTest/contact.test.js
+++ b/src/__tests__/appTest/contact.test.js
@@ -32,6 +32,6 @@ describe("Contact Page", () => {
   it("should render goBackButton", () => {
     const goBackButton = screen.getByTestId("go-back-button");
     expect(goBackButton).toBeInTheDocument();
-    expect(goBackButton).toHaveTextContent("Go back");
+    expect(goBackButton).toHaveTextContent("Tilbage");
   });
 });

--- a/src/__tests__/appTest/ourTeam.test.js
+++ b/src/__tests__/appTest/ourTeam.test.js
@@ -35,6 +35,6 @@ describe("OurTeam Page", () => {
   it("should render goBackButton", () => {
     const goBackButton = screen.getByTestId("go-back-button");
     expect(goBackButton).toBeInTheDocument();
-    expect(goBackButton).toHaveTextContent("Go back");
+    expect(goBackButton).toHaveTextContent("Tilbage");
   });
 });

--- a/src/__tests__/appTest/ourValues.test.js
+++ b/src/__tests__/appTest/ourValues.test.js
@@ -2,7 +2,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import OurValuesPage from "@/app/our-values/page";
 import { LanguageProvider } from "@/app/context/LanguageContext";
-import enTranslations from "../../translations/en.json";
+import dkTranslations from "../../translations/dk.json";
 
 jest.mock("../../components/OurValues/OurValues", () => {
   return jest.fn(() => (
@@ -12,7 +12,7 @@ jest.mock("../../components/OurValues/OurValues", () => {
 
 describe("OurValuesPage", () => {
   // Mock the screen size adjustment for small screens
-  const renderWithLanguage = (translations = enTranslations) => {
+  const renderWithLanguage = (translations = dkTranslations) => {
     return render(
       <LanguageProvider value={translations}>
         <OurValuesPage />
@@ -30,12 +30,12 @@ describe("OurValuesPage", () => {
 
     const goBackButton = screen.getByTestId("go-back-button");
     expect(goBackButton).toBeInTheDocument();
-    expect(goBackButton).toHaveTextContent("Go back");
+    expect(goBackButton).toHaveTextContent("Tilbage");
   });
 
   it("should render goBackButton", () => {
     const goBackButton = screen.getByTestId("go-back-button");
     expect(goBackButton).toBeInTheDocument();
-    expect(goBackButton).toHaveTextContent("Go back");
+    expect(goBackButton).toHaveTextContent("Tilbage");
   });
 });

--- a/src/__tests__/appTest/privacyPolicy.test.js
+++ b/src/__tests__/appTest/privacyPolicy.test.js
@@ -4,7 +4,7 @@ import PrivacyPolicy from "../../app/privacy-policy/page";
 import { LanguageProvider } from "../../app/context/LanguageContext";
 
 const mockTranslations = {
-  "button.go-back": "Go Back",
+  "button.go-back": "Tilbage",
   "privacy.h1": "Privacy Policy",
   "privacy.updated": "Last updated:",
   "privacy.h2-1": "Introduction",
@@ -60,7 +60,7 @@ describe("PrivacyPolicy Component", () => {
   });
 
   test("renders Go Back button with translation", () => {
-    expect(screen.getByTestId("go-back-button")).toHaveTextContent("Go back");
+    expect(screen.getByTestId("go-back-button")).toHaveTextContent("Tilbage");
   });
 
   test("renders the Privacy Policy title", () => {

--- a/src/__tests__/appTest/subscriptionConfirmed.test.js
+++ b/src/__tests__/appTest/subscriptionConfirmed.test.js
@@ -41,9 +41,7 @@ describe("SubscriptionConfirmed Page", () => {
   });
 
   it("renders with the correct background styles", () => {
-    const section = screen.getByLabelText(
-      /Thank you for verifying your email/i,
-    );
+    const section = screen.getByLabelText(/Tak for at verificere din e-mail/i);
     expect(section).toHaveClass("bg-primary-light");
     expect(section).toHaveClass("sm:bg-dots-lg");
     expect(section).toHaveClass("bg-dots-sm");

--- a/src/__tests__/appTest/subscriptionVerify.test.js
+++ b/src/__tests__/appTest/subscriptionVerify.test.js
@@ -54,7 +54,7 @@ describe("VerifyEmail Page", () => {
     renderWithLanguage();
 
     const verifyButton = screen.getByTestId("verify-button");
-    expect(verifyButton).toHaveTextContent(/verifying/i);
+    expect(verifyButton).toHaveTextContent(/Verificerer.../i);
     expect(verifyButton).toBeDisabled();
   });
 
@@ -71,7 +71,9 @@ describe("VerifyEmail Page", () => {
     await waitFor(() => {
       const errorMessage = screen.getByTestId("error-message");
       expect(errorMessage).toBeInTheDocument();
-      expect(errorMessage).toHaveTextContent(/verification token is missing/i);
+      expect(errorMessage).toHaveTextContent(
+        /Verifikationstoken mangler. Tjek venligst dit e-mail-link./i,
+      );
     });
   });
 

--- a/src/__tests__/appTest/unsubscribeRequest.test.js
+++ b/src/__tests__/appTest/unsubscribeRequest.test.js
@@ -3,7 +3,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import UnsubscribeRequestPage from "@/app/subscription/unsubscribe-request/page";
 import { LanguageProvider } from "@/app/context/LanguageContext";
-import enTranslations from "../../translations/en.json";
+import dkTranslations from "../../translations/dk.json";
 import useFetch from "@/hooks/api/useFetch";
 
 jest.mock("next/navigation", () => ({
@@ -35,7 +35,7 @@ describe("UnsubscribeRequestPage", () => {
     jest.clearAllMocks();
   });
 
-  const renderWithLanguage = (translations = enTranslations) => {
+  const renderWithLanguage = (translations = dkTranslations) => {
     return render(
       <LanguageProvider value={{ translations }}>
         <UnsubscribeRequestPage />
@@ -54,7 +54,7 @@ describe("UnsubscribeRequestPage", () => {
     renderWithLanguage();
 
     const unsubscribeButton = screen.getByTestId("unsubscribe-request-button");
-    expect(unsubscribeButton).toHaveTextContent(/submitting/i);
+    expect(unsubscribeButton).toHaveTextContent(/Indsender.../i);
     expect(unsubscribeButton).toBeDisabled();
   });
 
@@ -71,7 +71,9 @@ describe("UnsubscribeRequestPage", () => {
     await waitFor(() => {
       const errorMessage = screen.getByTestId("error-message");
       expect(errorMessage).toBeInTheDocument();
-      expect(errorMessage).toHaveTextContent(/unsubscribe token is missing/i);
+      expect(errorMessage).toHaveTextContent(
+        /Afmeldings-token mangler eller er ugyldigt. Tjek venligst din e-mail eller kontakt os for hjælp./i,
+      );
     });
   });
 
@@ -124,7 +126,7 @@ describe("UnsubscribeRequestPage", () => {
       performFetch: performFetchMock,
     });
     rerender(
-      <LanguageProvider value={{ translations: enTranslations }}>
+      <LanguageProvider value={{ translations: dkTranslations }}>
         <UnsubscribeRequestPage />
       </LanguageProvider>,
     );

--- a/src/__tests__/componentsTest/ContactUs.test.js
+++ b/src/__tests__/componentsTest/ContactUs.test.js
@@ -30,30 +30,30 @@ describe("ContactUs Component", () => {
   test("renders all info items correctly", () => {
     renderWithProvider("en");
 
-    const locationTitle = screen.getByText("Our Location");
+    const locationTitle = screen.getByText("Vores placering");
     const locationDescription = screen.getByText(
       "Christianshavns Voldgade 54, 1424 København",
     );
     expect(locationTitle).toBeInTheDocument();
     expect(locationDescription).toBeInTheDocument();
 
-    const phoneTitle = screen.getByText("Phone Number");
+    const phoneTitle = screen.getByText("Telefonnummer");
     const phoneDescription = screen.getByText("(+45) 31 62 06 93");
     expect(phoneTitle).toBeInTheDocument();
     expect(phoneDescription).toBeInTheDocument();
 
-    const emailTitle = screen.getByText("Email Address");
+    const emailTitle = screen.getByText("E-mailadresse");
     const emailDescription = screen.getByText("info@donnavino.dk");
     expect(emailTitle).toBeInTheDocument();
     expect(emailDescription).toBeInTheDocument();
   });
 
   test("renders correct icons for each info item", () => {
-    renderWithProvider("en");
+    renderWithProvider("dk");
 
-    const locationIcon = screen.getByAltText("Our Location");
-    const phoneIcon = screen.getByAltText("Phone Number");
-    const emailIcon = screen.getByAltText("Email Address");
+    const locationIcon = screen.getByAltText("Vores placering");
+    const phoneIcon = screen.getByAltText("Telefonnummer");
+    const emailIcon = screen.getByAltText("E-mailadresse");
 
     expect(locationIcon).toHaveAttribute("src", "/icons/location-red.svg");
     expect(phoneIcon).toHaveAttribute("src", "/icons/phone-map-red.svg");
@@ -61,12 +61,12 @@ describe("ContactUs Component", () => {
   });
 
   test("renders the form with all correct input fields", () => {
-    renderWithProvider("en");
+    renderWithProvider("dk");
 
-    const nameInput = screen.getByPlaceholderText("Your Name");
-    const emailInput = screen.getByPlaceholderText("Your Email");
-    const phoneInput = screen.getByPlaceholderText("Your Phone Number");
-    const messageTextarea = screen.getByPlaceholderText("Your Message");
+    const nameInput = screen.getByPlaceholderText("Dit Navn");
+    const emailInput = screen.getByPlaceholderText("Din E-mail");
+    const phoneInput = screen.getByPlaceholderText("Dit Telefonnummer");
+    const messageTextarea = screen.getByPlaceholderText("Din Besked");
 
     expect(nameInput).toBeInTheDocument();
     expect(nameInput).toHaveAttribute("type", "text");
@@ -82,10 +82,10 @@ describe("ContactUs Component", () => {
   });
 
   test("renders the Send Message button", () => {
-    renderWithProvider("en");
+    renderWithProvider("dk");
 
     const button = screen.getByTestId("secondary-normal-send-message-button");
     expect(button).toBeInTheDocument();
-    expect(button).toHaveTextContent("Send Message");
+    expect(button).toHaveTextContent("Sende Besked");
   });
 });

--- a/src/__tests__/componentsTest/Footer.test.js
+++ b/src/__tests__/componentsTest/Footer.test.js
@@ -26,7 +26,7 @@ MockLanguageProvider.propTypes = {
   language: PropTypes.oneOf(["en", "dk"]), // Restrict language to "en" or "dk"
 };
 
-const renderWithProvider = (language = "en", pathname = "/") => {
+const renderWithProvider = (language = "dk", pathname = "/") => {
   usePathname.mockReturnValue(pathname);
 
   render(
@@ -53,9 +53,9 @@ describe("on regular pages", () => {
   it("renders all navigation links", () => {
     renderWithProvider("en");
     const links = [
-      { id: "our-values", href: "/our-values", label: "Our Values" },
-      { id: "our-team", href: "/our-team", label: "Our Team" },
-      { id: "contact", href: "/contact", label: "Contact" },
+      { id: "our-values", href: "/our-values", label: "Vores Værdier" },
+      { id: "our-team", href: "/our-team", label: "Vores Team" },
+      { id: "contact", href: "/contact", label: "Kontakte" },
     ];
 
     links.forEach((link) => {

--- a/src/__tests__/componentsTest/HeroSection.test.js
+++ b/src/__tests__/componentsTest/HeroSection.test.js
@@ -7,7 +7,7 @@ import { LanguageProvider } from "@/app/context/LanguageContext";
 import enTranslations from "../../translations/en.json";
 import dkTranslations from "../../translations/dk.json";
 
-const MockLanguageProvider = ({ children, language = "en" }) => {
+const MockLanguageProvider = ({ children, language = "dk" }) => {
   const translations = language === "en" ? enTranslations : dkTranslations;
 
   return (
@@ -20,7 +20,7 @@ MockLanguageProvider.propTypes = {
   language: PropTypes.oneOf(["en", "dk"]),
 };
 
-const renderWithProvider = (language = "en") => {
+const renderWithProvider = (language = "dk") => {
   render(
     <MockLanguageProvider language={language}>
       <HeroSection />
@@ -34,7 +34,7 @@ describe("HeroSection Component", () => {
 
     // Check the heading text
     const heading = screen.getByText(
-      /Welcome to Donna Vino, your unique wine experience\./i,
+      /Velkommen til Donna Vino, din unikke vinoplevelse./i,
     );
     expect(heading).toBeInTheDocument();
 
@@ -42,7 +42,7 @@ describe("HeroSection Component", () => {
     const description = screen.getByTestId("description");
     expect(description).toBeInTheDocument();
     expect(description).toHaveTextContent(
-      "Discover unique wine stories told by your sommelier while your private chef customizes the menu.",
+      "Oplev unikke vinhistorier fortalt af din sommelier, mens din private kok tilpasser menuen.",
     );
 
     // Check that the dotted shapes images are present

--- a/src/__tests__/componentsTest/LanguageSwitch.test.js
+++ b/src/__tests__/componentsTest/LanguageSwitch.test.js
@@ -29,12 +29,12 @@ describe("LanguageSwitch component", () => {
     );
 
     const englishIcon = screen.getByTestId("en-icon");
-    expect(englishIcon).toHaveClass("bg-primary-light");
+    expect(englishIcon).toHaveClass("hover:bg-primary-light");
 
     const denmarkIcon = screen.getByTestId("dk-icon");
     fireEvent.click(denmarkIcon);
 
-    expect(denmarkIcon).toHaveClass("bg-primary-light");
+    expect(denmarkIcon).toHaveClass("hover:bg-primary-light");
     expect(englishIcon.classList.contains("bg-primary-light")).toBe(false);
   });
 });

--- a/src/__tests__/componentsTest/MapSection.test.js
+++ b/src/__tests__/componentsTest/MapSection.test.js
@@ -31,19 +31,19 @@ describe("MapSection Component", () => {
   test("renders all info items correctly", () => {
     renderWithProvider();
 
-    const locationTitle = screen.getByText("Our Location");
+    const locationTitle = screen.getByText("Vores placering");
     const locationDescription = screen.getByText(
       "Christianshavns Voldgade 54 - 1424 København",
     );
     expect(locationTitle).toBeInTheDocument();
     expect(locationDescription).toBeInTheDocument();
 
-    const phoneTitle = screen.getByText("Phone Number");
+    const phoneTitle = screen.getByText("Telefonnummer");
     const phoneDescription = screen.getByText("+45 31 62 06 93");
     expect(phoneTitle).toBeInTheDocument();
     expect(phoneDescription).toBeInTheDocument();
 
-    const emailTitle = screen.getByText("Email Address");
+    const emailTitle = screen.getByText("E-mailadresse");
     const emailDescription = screen.getByText("info@donnavino.dk");
     expect(emailTitle).toBeInTheDocument();
     expect(emailDescription).toBeInTheDocument();
@@ -57,9 +57,9 @@ describe("MapSection Component", () => {
 
   test("renders correct icons for each info item", () => {
     renderWithProvider();
-    const locationIcon = screen.getByAltText("Our Location");
-    const phoneIcon = screen.getByAltText("Phone Number");
-    const emailIcon = screen.getByAltText("Email Address");
+    const locationIcon = screen.getByAltText("Vores placering");
+    const phoneIcon = screen.getByAltText("Telefonnummer");
+    const emailIcon = screen.getByAltText("E-mailadresse");
 
     expect(locationIcon).toHaveAttribute("src", "/icons/location.svg");
     expect(phoneIcon).toHaveAttribute("src", "/icons/phone-map.svg");
@@ -81,13 +81,13 @@ describe("MapSection Component", () => {
   test("displays the correct information items", () => {
     renderWithProvider();
 
-    const locationTitle = screen.getByText(/Our Location/i);
+    const locationTitle = screen.getByText(/Vores placering/i);
     const locationDescription = screen.getByText(
       /Christianshavns Voldgade 54 - 1424 København/i,
     );
-    const phoneTitle = screen.getByText(/Phone Number/i);
+    const phoneTitle = screen.getByText(/Telefonnummer/i);
     const phoneDescription = screen.getByText(/\+45 31 62 06 93/i);
-    const emailTitle = screen.getByText(/Email Address/i);
+    const emailTitle = screen.getByText(/E-mailadresse/i);
     const emailDescription = screen.getByText(/info@donnavino.dk/i);
 
     expect(locationTitle).toBeInTheDocument();
@@ -101,7 +101,7 @@ describe("MapSection Component", () => {
   test('checks if the "Check on Maps" button is present and clickable', () => {
     renderWithProvider();
 
-    const checkMapsButton = screen.getByText(/Check on Maps/i);
+    const checkMapsButton = screen.getByText(/Tjek på Maps/i);
 
     expect(checkMapsButton).toBeInTheDocument();
 

--- a/src/__tests__/componentsTest/Navbar.test.js
+++ b/src/__tests__/componentsTest/Navbar.test.js
@@ -29,19 +29,19 @@ describe("Navbar component", () => {
 
     const homeLink = screen.getByTestId("nav-link-home");
     expect(homeLink).toBeInTheDocument();
-    expect(homeLink).toHaveTextContent("Home");
+    expect(homeLink).toHaveTextContent("Hjem");
 
     const ourValuesLink = screen.getByTestId("nav-link-our-values");
     expect(ourValuesLink).toBeInTheDocument();
-    expect(ourValuesLink).toHaveTextContent("Our Values");
+    expect(ourValuesLink).toHaveTextContent("Vores Værdier");
 
     const ourTeamLink = screen.getByTestId("nav-link-our-team");
     expect(ourTeamLink).toBeInTheDocument();
-    expect(ourTeamLink).toHaveTextContent("Our Team");
+    expect(ourTeamLink).toHaveTextContent("Vores Team");
 
     const contactLink = screen.getByTestId("nav-link-contact");
     expect(contactLink).toBeInTheDocument();
-    expect(contactLink).toHaveTextContent("Contact");
+    expect(contactLink).toHaveTextContent("Kontakte");
   });
 
   test("should have the correct links to pages", () => {

--- a/src/__tests__/componentsTest/Subscribe.test.js
+++ b/src/__tests__/componentsTest/Subscribe.test.js
@@ -12,7 +12,7 @@ import useFetch from "@/hooks/api/useFetch";
 jest.mock("@/hooks/api/useFetch", () => jest.fn());
 
 // Mock the LanguageProvider
-const MockLanguageProvider = ({ children, language = "en" }) => {
+const MockLanguageProvider = ({ children, language = "dk" }) => {
   const translations = language === "en" ? enTranslations : dkTranslations;
 
   return (
@@ -26,7 +26,7 @@ MockLanguageProvider.propTypes = {
 };
 
 // Helper function to render the component with the LanguageProvider
-const renderWithProvider = (language = "en") => {
+const renderWithProvider = (language = "dk") => {
   return render(
     <MockLanguageProvider language={language}>
       <Subscribe />
@@ -55,19 +55,19 @@ describe("Subscribe Component", () => {
     renderWithProvider();
 
     expect(
-      screen.getByText(enTranslations["subscribe.heading"]),
+      screen.getByText(dkTranslations["subscribe.heading"]),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(enTranslations["subscribe.paragraph"]),
+      screen.getByText(dkTranslations["subscribe.paragraph"]),
     ).toBeInTheDocument();
     expect(
-      screen.getByPlaceholderText(enTranslations["subscribe.placeholder"]),
+      screen.getByPlaceholderText(dkTranslations["subscribe.placeholder"]),
     ).toBeInTheDocument();
     expect(
-      screen.getByLabelText(enTranslations["subscribe.terms"]),
+      screen.getByLabelText(dkTranslations["subscribe.terms"]),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(enTranslations["subscribe.button"]),
+      screen.getByText(dkTranslations["subscribe.button"]),
     ).toBeInTheDocument();
   });
 
@@ -91,12 +91,12 @@ describe("Subscribe Component", () => {
     renderWithProvider();
 
     const emailInput = screen.getByPlaceholderText(
-      enTranslations["subscribe.placeholder"],
+      dkTranslations["subscribe.placeholder"],
     );
     const termsCheckbox = screen.getByLabelText(
-      enTranslations["subscribe.terms"],
+      dkTranslations["subscribe.terms"],
     );
-    const submitButton = screen.getByText(enTranslations["subscribe.button"]);
+    const submitButton = screen.getByText(dkTranslations["subscribe.button"]);
 
     fireEvent.change(emailInput, { target: { value: "test@example.com" } });
     fireEvent.click(termsCheckbox);
@@ -122,11 +122,11 @@ describe("Subscribe Component", () => {
 
     renderWithProvider();
 
-    const emailInput = screen.getByPlaceholderText(/Enter your email/i);
+    const emailInput = screen.getByPlaceholderText(/Indtast din e-mail/i);
     const termsCheckbox = screen.getByLabelText(
-      /I agree with the terms and conditions/i,
+      /Jeg accepterer vilkår og betingelser for tilmelding til nyhedsbrevet/i,
     );
-    const submitButton = screen.getByText(/Submit/i);
+    const submitButton = screen.getByText(/Indsend/i);
     fireEvent.change(emailInput, { target: { value: "test@example.com" } });
     fireEvent.click(termsCheckbox);
     fireEvent.click(submitButton);
@@ -166,7 +166,7 @@ describe("Subscribe Component", () => {
     renderWithProvider();
 
     const termsCheckbox = screen.getByLabelText(
-      enTranslations["subscribe.terms"],
+      dkTranslations["subscribe.terms"],
     );
 
     fireEvent.click(termsCheckbox);

--- a/src/__tests__/componentsTest/ThematicCard.test.js
+++ b/src/__tests__/componentsTest/ThematicCard.test.js
@@ -92,7 +92,7 @@ describe("ThematicCard Component", () => {
     descriptionEnd = screen.queryByText("This is the end of the description.");
     expect(descriptionEnd).toBeInTheDocument();
     expect(descriptionEnd).not.toHaveClass("hidden"); // Ensure it's visible
-    expect(button).toHaveTextContent("Show less");
+    expect(button).toHaveTextContent("Vise mindre");
 
     // Collapse the description
     act(() => {
@@ -103,21 +103,21 @@ describe("ThematicCard Component", () => {
     descriptionEnd = screen.queryByText("This is the end of the description.");
     expect(descriptionEnd).toBeInTheDocument();
     expect(descriptionEnd).toHaveClass("hidden"); // Ensure it's hidden, not removed
-    expect(button).toHaveTextContent("Show more");
+    expect(button).toHaveTextContent("Vise mere");
   });
 
   it("renders different layouts for small and large screens", async () => {
     renderWithSize(500); // Ensure small screen size
 
     // Ensure the layout for small screen
-    expect(screen.queryByText("Show more")).toBeInTheDocument();
+    expect(screen.queryByText("Vise mere")).toBeInTheDocument();
 
     // Mock large screen size inside the test and trigger a resize event
     renderWithSize(1200); // Simulate larger screen size
 
     // Wait for layout to update after resize
     await waitFor(() => {
-      expect(screen.queryByText("Show more")).not.toBeInTheDocument();
+      expect(screen.queryByText("Vise mere")).not.toBeInTheDocument();
     });
   });
 });

--- a/src/__tests__/componentsTest/ThematicCardsValues.test.js
+++ b/src/__tests__/componentsTest/ThematicCardsValues.test.js
@@ -47,7 +47,7 @@ describe("ThematicCardsValues Component", () => {
     );
 
     // Verify 'Show more' button is visible on small screens
-    const showMoreButton = screen.queryByText("Show more");
+    const showMoreButton = screen.queryByText("Vise mere");
     expect(showMoreButton).toBeInTheDocument();
   });
 

--- a/src/__tests__/componentsTest/ourValues.test.js
+++ b/src/__tests__/componentsTest/ourValues.test.js
@@ -7,7 +7,7 @@ import enTranslations from "../../translations/en.json";
 import dkTranslations from "../../translations/dk.json";
 import PropTypes from "prop-types";
 
-const MockLanguageProvider = ({ children, language = "en" }) => {
+const MockLanguageProvider = ({ children, language = "dk" }) => {
   const translations = language === "en" ? enTranslations : dkTranslations;
 
   return (
@@ -20,7 +20,7 @@ MockLanguageProvider.propTypes = {
   language: PropTypes.oneOf(["en", "dk"]),
 };
 
-const renderWithProvider = (language = "en") => {
+const renderWithProvider = (language = "dk") => {
   render(
     <MockLanguageProvider language={language}>
       <OurValuesPage />
@@ -39,7 +39,7 @@ describe("OurValues Component", () => {
     // Check the title
     const title = screen.getByTestId("title");
     expect(title).toBeInTheDocument();
-    expect(title).toHaveTextContent("Donna Vino Values");
+    expect(title).toHaveTextContent("Donna Vino Værdier");
 
     // Check the PhotoGallery container
     const photoGalleryContainer = screen.getByTestId("photoGallery-container");
@@ -70,20 +70,14 @@ describe("OurValues Component", () => {
     // Check the text content in the article
     const introParagraph = screen.getByTestId("intro-paragraph");
     expect(introParagraph).toBeInTheDocument();
-    expect(introParagraph).toHaveTextContent("Welcome to Donna Vino");
+    expect(introParagraph).toHaveTextContent("Velkommen til Donna Vino");
 
     const introParagraphDescription = screen.getByTestId(
       "intro-paragraph-description",
     );
     expect(introParagraphDescription).toBeInTheDocument();
     expect(introParagraphDescription).toHaveTextContent(
-      "Your destination for authentic Italian flavours.",
-    );
-
-    const descriptionParagraph = screen.getByTestId("description-paragraph");
-    expect(descriptionParagraph).toBeInTheDocument();
-    expect(descriptionParagraph).toHaveTextContent(
-      "Donna Vino is the result of former Michelin sommelier Katrine Giorgio's passion",
+      "Donna Vino fungerer som bindeleddet mellem passionerede italienske vinproducenter og vinelskere i Danmark. Vi tilbyder en vinoplevelse, hvor hver flaske afspejler sin oprindelse og det håndværk, der ligger bag. Vores fokus er på bæredygtig produktion, og vi giver dig mulighed for at opdage vine, der både udtrykker deres terroir og er ansvarligt produceret.",
     );
 
     // Check the Carousel component

--- a/src/__tests__/contextTest/LanguageContext.test.js
+++ b/src/__tests__/contextTest/LanguageContext.test.js
@@ -23,7 +23,37 @@ describe("LanguageProvider and LanguageSwitch", () => {
     );
   };
 
-  test("should default to 'en' language and display the correct translation", () => {
+  test("should default to 'dk' language and display the correct translation", () => {
+    render(
+      <LanguageProvider>
+        <TestComponent />
+      </LanguageProvider>,
+    );
+
+    expect(screen.getByText("dk")).toBeInTheDocument();
+    expect(screen.getByText(dkTranslations.welcomeMessage)).toBeInTheDocument();
+    expect(screen.getByText(dkTranslations.description)).toBeInTheDocument();
+    expect(screen.getByText(dkTranslations.footer)).toBeInTheDocument();
+  });
+
+  test("should change language to 'en' when English icon is clicked", () => {
+    render(
+      <LanguageProvider>
+        <TestComponent />
+      </LanguageProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId("en-icon"));
+
+    expect(screen.getByText("en")).toBeInTheDocument();
+    expect(screen.getByText(enTranslations.welcomeMessage)).toBeInTheDocument();
+    expect(screen.getByText(enTranslations.description)).toBeInTheDocument();
+    expect(screen.getByText(enTranslations.footer)).toBeInTheDocument();
+  });
+
+  test("should use saved language from localStorage", () => {
+    localStorage.setItem("pageLanguage", "en");
+
     render(
       <LanguageProvider>
         <TestComponent />
@@ -36,36 +66,6 @@ describe("LanguageProvider and LanguageSwitch", () => {
     expect(screen.getByText(enTranslations.footer)).toBeInTheDocument();
   });
 
-  test("should change language to 'dk' when Denmark icon is clicked", () => {
-    render(
-      <LanguageProvider>
-        <TestComponent />
-      </LanguageProvider>,
-    );
-
-    fireEvent.click(screen.getByTestId("dk-icon"));
-
-    expect(screen.getByText("dk")).toBeInTheDocument();
-    expect(screen.getByText(dkTranslations.welcomeMessage)).toBeInTheDocument();
-    expect(screen.getByText(dkTranslations.description)).toBeInTheDocument();
-    expect(screen.getByText(dkTranslations.footer)).toBeInTheDocument();
-  });
-
-  test("should use saved language from localStorage", () => {
-    localStorage.setItem("pageLanguage", "dk");
-
-    render(
-      <LanguageProvider>
-        <TestComponent />
-      </LanguageProvider>,
-    );
-
-    expect(screen.getByText("dk")).toBeInTheDocument();
-    expect(screen.getByText(dkTranslations.welcomeMessage)).toBeInTheDocument();
-    expect(screen.getByText(dkTranslations.description)).toBeInTheDocument();
-    expect(screen.getByText(dkTranslations.footer)).toBeInTheDocument();
-  });
-
   test("should store the selected language in localStorage", () => {
     render(
       <LanguageProvider>
@@ -73,13 +73,13 @@ describe("LanguageProvider and LanguageSwitch", () => {
       </LanguageProvider>,
     );
 
-    fireEvent.click(screen.getByTestId("dk-icon"));
+    fireEvent.click(screen.getByTestId("en-icon"));
 
-    expect(localStorage.getItem("pageLanguage")).toBe("dk");
+    expect(localStorage.getItem("pageLanguage")).toBe("en");
   });
 
   test("should reflect the selected language on reload", () => {
-    localStorage.setItem("pageLanguage", "dk");
+    localStorage.setItem("pageLanguage", "en");
 
     render(
       <LanguageProvider>
@@ -87,9 +87,9 @@ describe("LanguageProvider and LanguageSwitch", () => {
       </LanguageProvider>,
     );
 
-    expect(screen.getByText("dk")).toBeInTheDocument();
-    expect(screen.getByText(dkTranslations.welcomeMessage)).toBeInTheDocument();
-    expect(screen.getByText(dkTranslations.description)).toBeInTheDocument();
-    expect(screen.getByText(dkTranslations.footer)).toBeInTheDocument();
+    expect(screen.getByText("en")).toBeInTheDocument();
+    expect(screen.getByText(enTranslations.welcomeMessage)).toBeInTheDocument();
+    expect(screen.getByText(enTranslations.description)).toBeInTheDocument();
+    expect(screen.getByText(enTranslations.footer)).toBeInTheDocument();
   });
 });

--- a/src/app/context/LanguageContext.js
+++ b/src/app/context/LanguageContext.js
@@ -13,12 +13,14 @@ export const useLanguage = () => {
 };
 
 export const LanguageProvider = ({ children }) => {
-  const [language, setLanguage] = useState("en");
-  const [translations, setTranslations] = useState(enTranslations);
+  const [language, setLanguage] = useState("dk");
+  const [translations, setTranslations] = useState(dkTranslations);
   useEffect(() => {
-    const savedLanguage = localStorage.getItem("pageLanguage");
-    if (savedLanguage) {
-      setLanguage(savedLanguage);
+    if (typeof window !== "undefined") {
+      const savedLanguage = localStorage.getItem("pageLanguage");
+      if (savedLanguage) {
+        setLanguage(savedLanguage);
+      }
     }
   }, []);
 

--- a/src/components/Navbar/LanguageSwitch.js
+++ b/src/components/Navbar/LanguageSwitch.js
@@ -8,9 +8,7 @@ function LanguageSwitch() {
 
   useEffect(() => {
     const savedLanguage = localStorage.getItem("pageLanguage");
-    if (savedLanguage) {
-      setLanguage(savedLanguage);
-    }
+    setLanguage(savedLanguage || "dk");
   }, [setLanguage]);
 
   const handleLanguageChange = (newLanguage) => {


### PR DESCRIPTION
As per Katrines Request, the default language of the website should be changed to danish (since the website's users are mainly older danish people). In this PR this is achieved.

### Changes
- Changed the default language of the website to danish (changed in LanguageSwitch and LanguageContext)
- Updated all tests that started failing after the default language was switched

### Testing steps
1. Open the deployment
2. Ensure that danish is the language of the website
(If it is not you might need to delete the item pageLanguage that is stored in localStorage and try again)