### PR TITLE
Updating unsubscribe pages to match new unsubscribeController

### DIFF
--- a/src/__tests__/appTest/unsubscribeRequest.test.js
+++ b/src/__tests__/appTest/unsubscribeRequest.test.js
@@ -61,11 +61,7 @@ describe("UnsubscribeRequestPage", () => {
 
   it("shows error message when email is missing", async () => {
     require("next/navigation").useSearchParams.mockReturnValue({
-      get: jest.fn((key) => {
-        if (key === "uid") return "123456";
-        if (key === "sig") return "validsignature";
-        return null;
-      }),
+      get: jest.fn(() => null),
     });
 
     renderWithLanguage();
@@ -114,7 +110,7 @@ describe("UnsubscribeRequestPage", () => {
     expect(router.push).not.toHaveBeenCalled();
   });
 
-  it("handles unsubscribe process correctly when email is present", async () => {
+  it("handles unsubscribe process correctly when params are present", async () => {
     require("next/navigation").useSearchParams.mockReturnValue({
       get: jest.fn((key) => {
         if (key === "uid") return "123456";

--- a/src/__tests__/appTest/unsubscribeRequest.test.js
+++ b/src/__tests__/appTest/unsubscribeRequest.test.js
@@ -25,6 +25,8 @@ describe("UnsubscribeRequestPage", () => {
   let performFetchMock;
 
   beforeEach(() => {
+    jest.clearAllMocks();
+
     performFetchMock = jest.fn().mockResolvedValue({ success: true });
     useFetch.mockReturnValue({
       isLoading: false,
@@ -32,7 +34,6 @@ describe("UnsubscribeRequestPage", () => {
       data: null,
       performFetch: performFetchMock,
     });
-    jest.clearAllMocks();
   });
 
   const renderWithLanguage = (translations = dkTranslations) => {
@@ -60,7 +61,11 @@ describe("UnsubscribeRequestPage", () => {
 
   it("shows error message when email is missing", async () => {
     require("next/navigation").useSearchParams.mockReturnValue({
-      get: jest.fn(() => null),
+      get: jest.fn((key) => {
+        if (key === "uid") return "123456";
+        if (key === "sig") return "validsignature";
+        return null;
+      }),
     });
 
     renderWithLanguage();
@@ -111,7 +116,11 @@ describe("UnsubscribeRequestPage", () => {
 
   it("handles unsubscribe process correctly when email is present", async () => {
     require("next/navigation").useSearchParams.mockReturnValue({
-      get: jest.fn(() => "test@example.com"),
+      get: jest.fn((key) => {
+        if (key === "uid") return "123456";
+        if (key === "sig") return "validsignature";
+        return null;
+      }),
     });
 
     const { rerender } = renderWithLanguage();
@@ -165,9 +174,11 @@ describe("UnsubscribeRequestPage", () => {
 
   it("updates unsubscribe status when email is present but unsubscribe fails", async () => {
     require("next/navigation").useSearchParams.mockReturnValue({
-      get: jest.fn((key) =>
-        key === "email" ? "invalid@example.com@invalid.com" : null,
-      ),
+      get: jest.fn((key) => {
+        if (key === "uid") return "123456";
+        if (key === "sig") return "validsignature";
+        return null;
+      }),
     });
 
     performFetchMock.mockRejectedValueOnce(new Error("Unsubscribe failed"));

--- a/src/__tests__/appTest/unsubscribeRequest.test.js
+++ b/src/__tests__/appTest/unsubscribeRequest.test.js
@@ -72,7 +72,7 @@ describe("UnsubscribeRequestPage", () => {
       const errorMessage = screen.getByTestId("error-message");
       expect(errorMessage).toBeInTheDocument();
       expect(errorMessage).toHaveTextContent(
-        /E-mailadresse er påkrævet for at afmelde dig./i,
+        /e angivne parametre er ugyldige. Kontroller venligst dine input, og prøv igen./i,
       );
     });
   });

--- a/src/__tests__/appTest/unsubscribeRequest.test.js
+++ b/src/__tests__/appTest/unsubscribeRequest.test.js
@@ -58,7 +58,7 @@ describe("UnsubscribeRequestPage", () => {
     expect(unsubscribeButton).toBeDisabled();
   });
 
-  it("shows error message when token is missing", async () => {
+  it("shows error message when email is missing", async () => {
     require("next/navigation").useSearchParams.mockReturnValue({
       get: jest.fn(() => null),
     });
@@ -72,7 +72,7 @@ describe("UnsubscribeRequestPage", () => {
       const errorMessage = screen.getByTestId("error-message");
       expect(errorMessage).toBeInTheDocument();
       expect(errorMessage).toHaveTextContent(
-        /Afmeldings-token mangler eller er ugyldigt. Tjek venligst din e-mail eller kontakt os for hjælp./i,
+        /E-mailadresse er påkrævet for at afmelde dig./i,
       );
     });
   });
@@ -109,9 +109,9 @@ describe("UnsubscribeRequestPage", () => {
     expect(router.push).not.toHaveBeenCalled();
   });
 
-  it("handles unsubscribe process correctly", async () => {
+  it("handles unsubscribe process correctly when email is present", async () => {
     require("next/navigation").useSearchParams.mockReturnValue({
-      get: jest.fn(() => "valid-token"),
+      get: jest.fn(() => "test@example.com"),
     });
 
     const { rerender } = renderWithLanguage();
@@ -163,9 +163,11 @@ describe("UnsubscribeRequestPage", () => {
     );
   });
 
-  it("updates unsubscribe status when token is present but unsubscribe fails", async () => {
+  it("updates unsubscribe status when email is present but unsubscribe fails", async () => {
     require("next/navigation").useSearchParams.mockReturnValue({
-      get: jest.fn(() => "invalid-token"),
+      get: jest.fn((key) =>
+        key === "email" ? "invalid@example.com@invalid.com" : null,
+      ),
     });
 
     performFetchMock.mockRejectedValueOnce(new Error("Unsubscribe failed"));

--- a/src/app/subscription/unsubscribe-request/page.js
+++ b/src/app/subscription/unsubscribe-request/page.js
@@ -12,7 +12,8 @@ import SEO from "@/components/SEO/SEO";
 function UnsubscribeRequestContent({ translations }) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const email = searchParams.get("email");
+  const uid = searchParams.get("uid");
+  const sig = searchParams.get("sig");
 
   const [unsubscribeRequestStatus, setUnsubscribeRequestStatus] = useState({
     isRequesting: false,
@@ -25,10 +26,10 @@ function UnsubscribeRequestContent({ translations }) {
   );
 
   const handleUnsubscribeRequest = async () => {
-    if (!email) {
+    if (!uid || !sig) {
       setUnsubscribeRequestStatus({
         isRequesting: false,
-        error: translations["unsubscribe-request.error-email"],
+        error: translations["unsubscribe-request.error-params"],
       });
       return;
     }
@@ -40,7 +41,8 @@ function UnsubscribeRequestContent({ translations }) {
 
     try {
       await performFetch({
-        email: email,
+        uid,
+        sig,
       });
     } catch (err) {
       logInfo("Unsubscribe request error:", err);
@@ -129,6 +131,7 @@ UnsubscribeRequestContent.propTypes = {
   translations: PropTypes.shape({
     "unsubscribe-request.error-token": PropTypes.string.isRequired,
     "unsubscribe-request.error-email": PropTypes.string.isRequired,
+    "unsubscribe-request.error-params": PropTypes.string.isRequired,
     "unsubscribe-request.error-general": PropTypes.string.isRequired,
     "unsubscribe-request.heading": PropTypes.string.isRequired,
     "unsubscribe-request.paragraph1": PropTypes.string.isRequired,

--- a/src/app/subscription/unsubscribe-request/page.js
+++ b/src/app/subscription/unsubscribe-request/page.js
@@ -12,7 +12,7 @@ import SEO from "@/components/SEO/SEO";
 function UnsubscribeRequestContent({ translations }) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const token = searchParams.get("token");
+  const email = searchParams.get("email");
 
   const [unsubscribeRequestStatus, setUnsubscribeRequestStatus] = useState({
     isRequesting: false,
@@ -25,10 +25,10 @@ function UnsubscribeRequestContent({ translations }) {
   );
 
   const handleUnsubscribeRequest = async () => {
-    if (!token) {
+    if (!email) {
       setUnsubscribeRequestStatus({
         isRequesting: false,
-        error: translations["unsubscribe-request.error-token"],
+        error: translations["unsubscribe-request.error-email"],
       });
       return;
     }
@@ -40,8 +40,7 @@ function UnsubscribeRequestContent({ translations }) {
 
     try {
       await performFetch({
-        token: token,
-        subject: "Unsubscribe Request",
+        email: email,
       });
     } catch (err) {
       logInfo("Unsubscribe request error:", err);

--- a/src/app/subscription/unsubscribe-request/page.js
+++ b/src/app/subscription/unsubscribe-request/page.js
@@ -128,6 +128,7 @@ function UnsubscribeRequestContent({ translations }) {
 UnsubscribeRequestContent.propTypes = {
   translations: PropTypes.shape({
     "unsubscribe-request.error-token": PropTypes.string.isRequired,
+    "unsubscribe-request.error-email": PropTypes.string.isRequired,
     "unsubscribe-request.error-general": PropTypes.string.isRequired,
     "unsubscribe-request.heading": PropTypes.string.isRequired,
     "unsubscribe-request.paragraph1": PropTypes.string.isRequired,

--- a/src/translations/dk.json
+++ b/src/translations/dk.json
@@ -43,6 +43,7 @@
   "unsubscribe-request.button-loading": "Indsender...",
   "unsubscribe-request.error-token": "Afmeldings-token mangler eller er ugyldigt. Tjek venligst din e-mail eller kontakt os for hjælp.",
   "unsubscribe-request.error-email": "E-mailadresse er påkrævet for at afmelde dig.",
+  "unsubscribe-request.error-params": "De angivne parametre er ugyldige. Kontroller venligst dine input, og prøv igen.",
   "unsubscribe-request.error-general": "Der opstod en fejl under behandlingen af din afmeldingsanmodning. Prøv venligst igen senere.",
   "unsubscribed.title": "Afmeldt | Donna Vino",
   "unsubscribed.description": "Du er nu afmeldt Donna Vinos nyhedsbrev. Vi er kede af at se dig gå.",

--- a/src/translations/dk.json
+++ b/src/translations/dk.json
@@ -42,6 +42,7 @@
   "unsubscribe-request.button": "Indsend anmodning om afmelding",
   "unsubscribe-request.button-loading": "Indsender...",
   "unsubscribe-request.error-token": "Afmeldings-token mangler eller er ugyldigt. Tjek venligst din e-mail eller kontakt os for hjælp.",
+  "unsubscribe-request.error-email": "E-mailadresse er påkrævet for at afmelde dig.",
   "unsubscribe-request.error-general": "Der opstod en fejl under behandlingen af din afmeldingsanmodning. Prøv venligst igen senere.",
   "unsubscribed.title": "Afmeldt | Donna Vino",
   "unsubscribed.description": "Du er nu afmeldt Donna Vinos nyhedsbrev. Vi er kede af at se dig gå.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -43,6 +43,7 @@
   "unsubscribe-request.button-loading": "Submitting...",
   "unsubscribe-request.error-token": "The unsubscribe token is missing or invalid. Please check your email or contact us for assistance.",
   "unsubscribe-request.error-email": "Email is required to unsubscribe.",
+  "unsubscribe-request.error-params": "The provided parameters are invalid. Please check your input and try again.",
   "unsubscribe-request.error-general": "An error occurred while processing your unsubscribe request. Please try again later.",
   "unsubscribed.title": "Unsubscribed | Donna Vino",
   "unsubscribed.description": "You have successfully unsubscribed from the Donna Vino newsletter. We're sorry to see you go.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -42,6 +42,7 @@
   "unsubscribe-request.button": "Submit Unsubscribe Request",
   "unsubscribe-request.button-loading": "Submitting...",
   "unsubscribe-request.error-token": "The unsubscribe token is missing or invalid. Please check your email or contact us for assistance.",
+  "unsubscribe-request.error-email": "Email is required to unsubscribe.",
   "unsubscribe-request.error-general": "An error occurred while processing your unsubscribe request. Please try again later.",
   "unsubscribed.title": "Unsubscribed | Donna Vino",
   "unsubscribed.description": "You have successfully unsubscribed from the Donna Vino newsletter. We're sorry to see you go.",


### PR DESCRIPTION
In this PR, the "/subscription/unsubscribe-request"-page was changed in order to match the new subscribe- and unsubscribeControllers which now send uid (UserID) and sig (a HMAC-signature) as query-parameters, and not token or email as before. Along with this, a new error-message needed to be added. Also, the test needed to be modified slightly to match these changes.

### Changes
- Update unsubscribe-request page to accept uid and sig as query-parameters (instead of token as before)
- Added new error-messages (+ translations)
- Updated test for the page to match the newest conditions

### Testing
- Can be tested along with the backend-branch "feature/tokengenerator-refactor-simon".
- Set it up locally and check if you can successfully unsubscribe

### Additional thoughts
As Halyna mentioned in a comment, this page still uses the old useFetch-function. Its replacement, useAPI, has not yet been implemented in the corporate repo. I think this refactor is a bit too big to be part of this task (which in turn is part of task #220 "Make Changes after the tokenGenerator Refactor") and should be handled in another, separate PR.
